### PR TITLE
Validation, Converter and tests Improvements 

### DIFF
--- a/docs/Convert.md
+++ b/docs/Convert.md
@@ -18,20 +18,21 @@ errors.
 
 #### Example(Model to XML) 
 ```scala
-  import advxml.implicits._
-  import advxml.core.validate.ValidatedEx
-  import advxml.core.convert.ModelToXml
-  import scala.xml._
-  import cats.implicits._
-  import cats.data.Validated.Valid
+    import advxml.implicits._
+    import advxml.core.validate.ValidatedEx
+    import advxml.core.convert.xml.ModelToXml
+    import scala.xml._
+    import cats.data.Kleisli
+    import cats.implicits._
+    import cats.data.Validated.Valid
 
   case class Person(name: String, surname: String, age: Option[Int])
   
-  implicit val converter: ModelToXml[Person, Elem] = x =>
+  implicit val converter: ModelToXml[Person, Elem] = Kleisli(x =>
     Valid {
       <Person Name={x.name} Surname={x.surname} Age={x.age.map(_.toString).getOrElse("")}/>
-    }
+    })
   
   val p = Person("Matteo", "Bianchi", Some(23))
-  val res: ValidatedEx[Elem] = p.asXml
+  val res: ValidatedEx[Elem] = p.as[Elem]
 ```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,8 +15,9 @@ object Dependencies {
     //XML
     "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1" cross CrossVersion.binary,
     //TEST
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test cross CrossVersion.binary,
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test cross CrossVersion.binary,
-    "org.scalacheck" %% "scalacheck" % "1.14.2" % Test cross CrossVersion.binary
+    "org.typelevel" %% "cats-laws" % "2.1.0" % Test cross CrossVersion.binary,
+    "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,
+    "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,
+    "org.scalacheck" %% "scalacheck" % "1.14.3" % Test cross CrossVersion.binary
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
     //XML
     "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1" cross CrossVersion.binary,
     //TEST
+    "org.typelevel" %% "discipline-scalatest" % "1.0.0-RC2" % Test,
     "org.typelevel" %% "cats-laws" % "2.1.0" % Test cross CrossVersion.binary,
     "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,
     "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,

--- a/src/main/scala/advxml/core/convert/Converter.scala
+++ b/src/main/scala/advxml/core/convert/Converter.scala
@@ -20,7 +20,7 @@ object Converter {
     * @tparam F Effect type
     * @tparam A Input type
     * @tparam B Output type
-    * @return
+    * @return Converter instance
     */
   def of[F[_], A, B](f: A => F[B]): Converter[F, A, B] = Kleisli(f)
 

--- a/src/main/scala/advxml/core/convert/package.scala
+++ b/src/main/scala/advxml/core/convert/package.scala
@@ -4,7 +4,7 @@ import advxml.core.validate.ValidatedEx
 import cats.Id
 import cats.data.Kleisli
 
-import scala.xml.{NodeSeq, Text}
+import scala.xml.NodeSeq
 
 package object convert {
 
@@ -39,17 +39,6 @@ package object convert {
     * @tparam B Output object type
     */
   type ValidatedConverter[-A, B] = Converter[ValidatedEx, A, B]
-
-  /**
-    * Represents a function `A => Text` to simplify method and class signatures.
-    * This alias represent an unsafe converter to transform `A` into `Text`.
-    *
-    * The invocation of this function can fail and/or throw an runtime exception.
-    *
-    * @see [[advxml.core.convert.PureConverter]] for further information.
-    * @tparam A Contravariant input object type
-    */
-  type TextConverter[-A] = PureConverter[A, Text]
 
   /**
     * Represents a function `O => ValidatedEx[NodeSeq]` to simplify method and class signatures.

--- a/src/main/scala/advxml/core/convert/package.scala
+++ b/src/main/scala/advxml/core/convert/package.scala
@@ -4,8 +4,6 @@ import advxml.core.validate.ValidatedEx
 import cats.Id
 import cats.data.Kleisli
 
-import scala.xml.NodeSeq
-
 package object convert {
 
   /**
@@ -39,26 +37,4 @@ package object convert {
     * @tparam B Output object type
     */
   type ValidatedConverter[-A, B] = Converter[ValidatedEx, A, B]
-
-  /**
-    * Represents a function `O => ValidatedEx[NodeSeq]` to simplify method and class signatures.
-    * This function transform a model of type `O` to standard scala-xml library `NodeSeq`, in this case `X`.
-    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors
-    *
-    * @see [[ValidatedConverter]] for further information.
-    * @tparam O Contravariant input model type
-    * @tparam X Output xml type, type constraint ensures that `X` is a subtype of scala-xml `NodeSeq`
-    */
-  type ModelToXml[-O, X <: NodeSeq] = ValidatedConverter[O, X]
-
-  /**
-    * Represents a function `NodeSeq => ValidatedEx[O]` to simplify method and class signatures.
-    * This function transform xml model of type `X`, from standard scala-xml library, into a model of type `O`
-    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors
-    *
-    * @see [[ValidatedConverter]] for further information.
-    * @tparam X Contravariant input xml model, type constraint ensures that `X` is a subtype of scala-xml `NodeSeq`
-    * @tparam O Output model type
-    */
-  type XmlToModel[-X <: NodeSeq, O] = ValidatedConverter[X, O]
 }

--- a/src/main/scala/advxml/core/convert/xml/XmlConverter.scala
+++ b/src/main/scala/advxml/core/convert/xml/XmlConverter.scala
@@ -1,5 +1,7 @@
-package advxml.core.convert
+package advxml.core.convert.xml
 
+import advxml.core.convert
+import advxml.core.convert.ValidatedConverter
 import advxml.core.validate.ValidatedEx
 
 import scala.annotation.implicitNotFound
@@ -34,5 +36,6 @@ object XmlConverter {
     * @return [[advxml.core.validate.ValidatedEx]] instance that, if on success case contains `O` instance.
     */
   @implicitNotFound("Missing ModelToXml to transform ${O} into ValidatedEx[${X}]")
-  def asXml[O: ModelToXml[*, X], X <: NodeSeq](model: O): ValidatedEx[X] = ValidatedConverter[O, X].run(model)
+  def asXml[O: convert.xml.ModelToXml[*, X], X <: NodeSeq](model: O): ValidatedEx[X] =
+    ValidatedConverter[O, X].run(model)
 }

--- a/src/main/scala/advxml/core/convert/xml/xml.scala
+++ b/src/main/scala/advxml/core/convert/xml/xml.scala
@@ -1,0 +1,28 @@
+package advxml.core.convert
+
+import scala.xml.NodeSeq
+
+package object xml {
+
+  /**
+    * Represents a function `O => ValidatedEx[NodeSeq]` to simplify method and class signatures.
+    * This function transform a model of type `O` to standard scala-xml library `NodeSeq`, in this case `X`.
+    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors
+    *
+    * @see [[ValidatedConverter]] for further information.
+    * @tparam O Contravariant input model type
+    * @tparam X Output xml type, type constraint ensures that `X` is a subtype of scala-xml `NodeSeq`
+    */
+  type ModelToXml[-O, X <: NodeSeq] = ValidatedConverter[O, X]
+
+  /**
+    * Represents a function `NodeSeq => ValidatedEx[O]` to simplify method and class signatures.
+    * This function transform xml model of type `X`, from standard scala-xml library, into a model of type `O`
+    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors
+    *
+    * @see [[ValidatedConverter]] for further information.
+    * @tparam X Contravariant input xml model, type constraint ensures that `X` is a subtype of scala-xml `NodeSeq`
+    * @tparam O Output model type
+    */
+  type XmlToModel[-X <: NodeSeq, O] = ValidatedConverter[X, O]
+}

--- a/src/main/scala/advxml/core/validate/ValidatedEx.scala
+++ b/src/main/scala/advxml/core/validate/ValidatedEx.scala
@@ -24,7 +24,7 @@ object ValidatedEx {
   def transformE[F[_], A](validated: ValidatedEx[A])(implicit F: MonadEx[F]): F[A] = {
     validated match {
       case Valid(value) => F.pure(value)
-      case Invalid(exs) => F.raiseError(new AggregatedException(exs.toList))
+      case Invalid(exs) => F.raiseError(new AggregatedException(exs))
     }
   }
 

--- a/src/main/scala/advxml/core/validate/exceptions/AggregatedException.scala
+++ b/src/main/scala/advxml/core/validate/exceptions/AggregatedException.scala
@@ -2,21 +2,23 @@ package advxml.core.validate.exceptions
 
 import java.io.{OutputStreamWriter, PrintStream, PrintWriter}
 
+import cats.data.NonEmptyList
+
 /**
   * Advxml
   * Created by geirolad on 11/07/2019.
   *
   * @author geirolad
   */
-class AggregatedException(exceptions: Seq[Throwable])
+class AggregatedException(val exceptions: NonEmptyList[Throwable])
     extends RuntimeException(
-      exceptions
+      exceptions.toList
         .map(_.getMessage)
         .mkString(",\n")
     ) {
 
   def getStackTraces: Map[Throwable, Array[StackTraceElement]] =
-    exceptions.map(e => (e, e.getStackTrace)).toMap
+    exceptions.toList.map(e => (e, e.getStackTrace)).toMap
 
   override def printStackTrace(): Unit = printStackTrace(System.err)
 
@@ -24,7 +26,7 @@ class AggregatedException(exceptions: Seq[Throwable])
     printStackTrace(new PrintWriter(new OutputStreamWriter(s)))
 
   override def printStackTrace(s: PrintWriter): Unit =
-    exceptions.foreach(e => {
+    exceptions.toList.foreach(e => {
       e.printStackTrace(s)
       s.print(s"\n\n${(0 to 70).map(_ => "#").mkString("")}\n\n")
     })

--- a/src/main/scala/advxml/instances/ConvertersInstances.scala
+++ b/src/main/scala/advxml/instances/ConvertersInstances.scala
@@ -1,9 +1,11 @@
 package advxml.instances
 
-import advxml.core.convert.{Converter, PureConverter, TextConverter}
+import advxml.core.convert.{Converter, PureConverter}
+import advxml.core.validate.MonadEx
 import cats.Applicative
 
 import scala.math.ScalaNumber
+import scala.util.{Success, Try}
 import scala.xml.Text
 
 private[instances] trait ConvertersInstances extends CommonConvertersInstances with TextConverterInstances
@@ -13,22 +15,41 @@ private[instances] sealed trait CommonConvertersInstances {
   implicit def pureIdentityConverter[A]: PureConverter[A, A] = PureConverter.id[A]
 }
 
-/**
-  * This trait provides standard and basic implementations of common [[TextConverter]].
-  */
 private[instances] sealed trait TextConverterInstances {
+
   // format: off
-  implicit val text_converter_text         : TextConverter[Text]         = Converter.id
-  implicit val text_converter_string       : TextConverter[String]       = toText[String]
-  implicit val text_converter_scalaNumber  : TextConverter[ScalaNumber]  = toText[ScalaNumber]
-  implicit val text_converter_byte         : TextConverter[Byte]         = toText[Byte]
-  implicit val text_converter_short        : TextConverter[Short]        = toText[Short]
-  implicit val text_converter_char         : TextConverter[Char]         = toText[Char]
-  implicit val text_converter_int          : TextConverter[Int]          = toText[Int]
-  implicit val text_converter_long         : TextConverter[Long]         = toText[Long]
-  implicit val text_converter_float        : TextConverter[Float]        = toText[Float]
-  implicit val text_converter_double       : TextConverter[Double]       = toText[Double]
+  implicit def text_converter_text       [F[_] : Applicative]  : Converter[F, Text, Text]         = Converter.id
+  implicit def text_converter_string     [F[_] : Applicative]  : Converter[F, String, Text]       = toText
+  implicit def text_converter_scalaNumber[F[_] : Applicative]  : Converter[F, ScalaNumber, Text]  = toText
+  implicit def text_converter_byte       [F[_] : Applicative]  : Converter[F, Byte, Text]         = toText
+  implicit def text_converter_short      [F[_] : Applicative]  : Converter[F, Short, Text]        = toText
+  implicit def text_converter_char       [F[_] : Applicative]  : Converter[F, Char, Text]         = toText
+  implicit def text_converter_int        [F[_] : Applicative]  : Converter[F, Int, Text]          = toText
+  implicit def text_converter_long       [F[_] : Applicative]  : Converter[F, Long, Text]         = toText
+  implicit def text_converter_float      [F[_] : Applicative]  : Converter[F, Float, Text]        = toText
+  implicit def text_converter_double     [F[_] : Applicative]  : Converter[F, Double, Text]       = toText
+
+  implicit def string_converter_text     [F[_] : MonadEx]  : Converter[F, Text, String] =
+    toT(Success(_))
+  implicit def byte_converter_text       [F[_] : MonadEx]  : Converter[F, Text, Byte]   =
+    toT(v => Try(v.toByte))
+  implicit def char_converter_text       [F[_] : MonadEx]  : Converter[F, Text, Char]   =
+    toT(v => Try(v.toCharArray.apply(0)))
+  implicit def short_converter_text      [F[_] : MonadEx]  : Converter[F, Text, Short]  =
+    toT(v => Try(v.toShort))
+  implicit def int_converter_text        [F[_] : MonadEx]  : Converter[F, Text, Int]    =
+    toT(v => Try(v.toInt))
+  implicit def long_converter_text       [F[_] : MonadEx]  : Converter[F, Text, Long]  =
+    toT(v => Try(v.toLong))
+  implicit def float_converter_text      [F[_] : MonadEx]  : Converter[F, Text, Float]  =
+    toT(v => Try(v.toFloat))
+  implicit def double_converter_text     [F[_] : MonadEx]  : Converter[F, Text, Double] =
+    toT(v => Try(v.toDouble))
+
   
-  private def toText[I] : TextConverter[I] = PureConverter.of(v => Text(v.toString))
+  private def toText[F[_] : Applicative, I] : Converter[F, I, Text] = 
+    Converter.of(v => Applicative[F].pure(Text(v.toString)))
+  private def toT[F[_] : MonadEx, O](f: String => Try[O]) : Converter[F, Text, O]    =
+    Converter.of(t => MonadEx[F].fromTry(Try(t.text).flatMap(f)))
   // format: on
 }

--- a/src/main/scala/advxml/syntax/XmlTransformerSyntax.scala
+++ b/src/main/scala/advxml/syntax/XmlTransformerSyntax.scala
@@ -1,6 +1,6 @@
 package advxml.syntax
 
-import advxml.core.convert.{PureConverter, TextConverter}
+import advxml.core.convert.PureConverter
 import advxml.core.transform._
 import advxml.core.transform.actions.{AttributeData, ComposableXmlModifier, FinalXmlModifier}
 import advxml.core.transform.actions.XmlZoom.XmlZoom
@@ -43,7 +43,7 @@ private[syntax] sealed trait RuleSyntax {
 
 private[syntax] sealed trait ModifierSyntax {
   implicit class AttributeDataBuilder(q: String) {
-    def :=[T: TextConverter](v: T): AttributeData = AttributeData(q, PureConverter[T, Text].run(v))
+    def :=[T](v: T)(implicit C: PureConverter[T, Text]): AttributeData = AttributeData(q, C.run(v))
   }
 }
 

--- a/src/test/scala/advxml/core/PredicateTests.scala
+++ b/src/test/scala/advxml/core/PredicateTests.scala
@@ -1,8 +1,8 @@
 package advxml.core
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PredicateTests extends FunSuite with PredicateAsserts {
+class PredicateTests extends AnyFunSuite with PredicateAsserts {
 
   test("Combine two predicate with in and") {
     testAnd((p1, p2) => Predicate.and(p1, p2))

--- a/src/test/scala/advxml/core/XmlNormalizerTest.scala
+++ b/src/test/scala/advxml/core/XmlNormalizerTest.scala
@@ -1,10 +1,10 @@
 package advxml.core
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.{Comment, Group, NodeSeq}
 
-class XmlNormalizerTest extends FunSuite with XmlNormalizerAsserts {
+class XmlNormalizerTest extends AnyFunSuite with XmlNormalizerAsserts {
 
   test("XmlNormalizer - Normalize | with Elem") {
     assert_normalized_Equals(n => XmlNormalizer.normalize(n))

--- a/src/test/scala/advxml/core/XmlNormalizerTest.scala
+++ b/src/test/scala/advxml/core/XmlNormalizerTest.scala
@@ -19,7 +19,7 @@ class XmlNormalizerTest extends FunSuite with XmlNormalizerAsserts {
   }
 }
 
-trait XmlNormalizerAsserts {
+private[advxml] trait XmlNormalizerAsserts {
 
   def assert_normalized_Equals(f: NodeSeq => NodeSeq): Unit = {
     val v1 =

--- a/src/test/scala/advxml/core/convert/ConverterTest.scala
+++ b/src/test/scala/advxml/core/convert/ConverterTest.scala
@@ -1,11 +1,11 @@
 package advxml.core.convert
 
 import cats.Id
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Try
 
-class ConverterTest extends FunSuite {
+class ConverterTest extends AnyFunSuite {
 
   test("Test Converter.id") {
     import cats.instances.try_._

--- a/src/test/scala/advxml/core/convert/ValidatedConverterTest.scala
+++ b/src/test/scala/advxml/core/convert/ValidatedConverterTest.scala
@@ -2,9 +2,9 @@ package advxml.core.convert
 
 import advxml.core.validate.ValidatedEx
 import cats.data.Validated.Valid
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ValidatedConverterTest extends FunSuite {
+class ValidatedConverterTest extends AnyFunSuite {
 
   test("Test ValidatedConverter.of") {
     val converter: ValidatedConverter[Int, String] = ValidatedConverter.of(int => Valid(int.toString))

--- a/src/test/scala/advxml/core/convert/xml/XmlConverterTest.scala
+++ b/src/test/scala/advxml/core/convert/xml/XmlConverterTest.scala
@@ -2,11 +2,11 @@ package advxml.core.convert.xml
 
 import advxml.core.convert.ValidatedConverter
 import cats.data.Validated.Valid
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.Elem
 
-class XmlConverterTest extends FunSuite {
+class XmlConverterTest extends AnyFunSuite {
 
   test("XmlConverter - asModel") {
 

--- a/src/test/scala/advxml/core/convert/xml/XmlConverterTest.scala
+++ b/src/test/scala/advxml/core/convert/xml/XmlConverterTest.scala
@@ -1,5 +1,6 @@
-package advxml.core.convert
+package advxml.core.convert.xml
 
+import advxml.core.convert.ValidatedConverter
 import cats.data.Validated.Valid
 import org.scalatest.FunSuite
 

--- a/src/test/scala/advxml/core/transform/StressTest.scala
+++ b/src/test/scala/advxml/core/transform/StressTest.scala
@@ -2,12 +2,12 @@ package advxml.core.transform
 
 import advxml.core.transform.actions.XmlZoom
 import advxml.core.transform.actions.XmlZoom.XmlZoom
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Try
 import scala.xml.XML
 
-class StressTest extends FunSuite {
+class StressTest extends AnyFunSuite {
 
   import advxml.instances.convert._
   import advxml.instances.transform._

--- a/src/test/scala/advxml/core/utils/JavaXmlConvertersTest.scala
+++ b/src/test/scala/advxml/core/utils/JavaXmlConvertersTest.scala
@@ -3,7 +3,7 @@ package advxml.core.utils
 import java.io.StringReader
 
 import javax.xml.parsers.{DocumentBuilder, DocumentBuilderFactory}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.{Elem, InputSource, Node}
 
@@ -13,12 +13,15 @@ import scala.xml.{Elem, InputSource, Node}
   *
   * @author geirolad
   */
-class JavaXmlConvertersTest extends FunSuite {
+class JavaXmlConvertersTest extends AnyFunSuite {
 
   import JavaXmlConverters._
 
-  private val xmlStr: String = "<Test T1=\"TEST\"><NestedTest T2=\"NestedTest\"/>TEXT</Test>"
-  private val xml: Elem = <Test T1="TEST"><NestedTest T2="NestedTest"/>TEXT</Test>
+  lazy val javaDocBuilder: DocumentBuilder = DocumentBuilderFactory
+    .newInstance()
+    .newDocumentBuilder()
+  lazy val buildJavaDoc: String => JDocument = xmlString =>
+    javaDocBuilder.parse(new InputSource(new StringReader(xmlString)))
 
   test("Convert Java w3c Node to Scala xml Node") {
     val jDocument: JNode = buildJavaDoc(xmlStr)
@@ -47,11 +50,6 @@ class JavaXmlConvertersTest extends FunSuite {
 
     assert(jDocAsStr == xmlStr)
   }
-
-  lazy val javaDocBuilder: DocumentBuilder = DocumentBuilderFactory
-    .newInstance()
-    .newDocumentBuilder()
-
-  lazy val buildJavaDoc: String => JDocument = xmlString =>
-    javaDocBuilder.parse(new InputSource(new StringReader(xmlString)))
+  private val xmlStr: String = "<Test T1=\"TEST\"><NestedTest T2=\"NestedTest\"/>TEXT</Test>"
+  private val xml: Elem = <Test T1="TEST"><NestedTest T2="NestedTest"/>TEXT</Test>
 }

--- a/src/test/scala/advxml/core/utils/internals/MutableSingleUseTest.scala
+++ b/src/test/scala/advxml/core/utils/internals/MutableSingleUseTest.scala
@@ -1,8 +1,8 @@
 package advxml.core.utils.internals
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class MutableSingleUseTest extends FunSuite {
+class MutableSingleUseTest extends AnyFunSuite {
 
   test("SingleUse - getOrElse - unused") {
     val value = MutableSingleUse[String]("TEST")

--- a/src/test/scala/advxml/core/validate/MonadExUtilsTest.scala
+++ b/src/test/scala/advxml/core/validate/MonadExUtilsTest.scala
@@ -1,10 +1,10 @@
 package advxml.core.validate
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Try
 
-class MonadExUtilsTest extends FunSuite {
+class MonadExUtilsTest extends AnyFunSuite {
 
   test("Test get implicit MonadEx instance using apply method") {
     import cats.instances.try_._

--- a/src/test/scala/advxml/core/validate/ValidateExTest.scala
+++ b/src/test/scala/advxml/core/validate/ValidateExTest.scala
@@ -1,11 +1,11 @@
 package advxml.core.validate
 
 import cats.data.{NonEmptyList, Validated}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.{Failure, Success, Try}
 
-class ValidateExTest extends FunSuite with ValidatedExAsserts {
+class ValidateExTest extends AnyFunSuite with ValidatedExAsserts {
 
   //Transform
   test("Test ValidatedEx.transformE[Try] - Valid") {
@@ -93,11 +93,6 @@ private[advxml] trait ValidatedExAsserts {
     new RuntimeException("TEXT_EX_1"),
     new RuntimeException("TEXT_EX_2")
   )
-  private def assertValid[T](v: ValidatedEx[T], expectedValue: => T): Unit = {
-    assert(v.isValid)
-    assert(v.toOption.get == expectedValue)
-  }
-  private def assertInvalid(v: ValidatedEx[_]): Unit = assert(v.isInvalid)
 
   def assert_ValidatedEx_to_Try_Valid(f: ValidatedEx[String] => Try[String]): Unit = {
     val value = "TEST"
@@ -195,6 +190,8 @@ private[advxml] trait ValidatedExAsserts {
     assertInvalid(validatedExValue)
   }
 
+  private def assertInvalid(v: ValidatedEx[_]): Unit = assert(v.isInvalid)
+
   def assert_EitherNelEx_Right(f: EitherNelEx[String] => ValidatedEx[String]): Unit = {
     val value = "TEST"
     val eitherValue: EitherNelEx[String] = Right(value)
@@ -217,6 +214,11 @@ private[advxml] trait ValidatedExAsserts {
     val validatedExValue = f(optionValue, TEST_EXCEPTION)
 
     assertValid(validatedExValue, value)
+  }
+
+  private def assertValid[T](v: ValidatedEx[T], expectedValue: => T): Unit = {
+    assert(v.isValid)
+    assert(v.toOption.get == expectedValue)
   }
 
   def assert_Option_None(f: (Option[String], Throwable) => ValidatedEx[String]): Unit = {

--- a/src/test/scala/advxml/core/validate/exeptions/AggregatedExceptionTest.scala
+++ b/src/test/scala/advxml/core/validate/exeptions/AggregatedExceptionTest.scala
@@ -1,6 +1,7 @@
 package advxml.core.validate.exeptions
 
 import advxml.core.validate.exceptions.AggregatedException
+import cats.data.NonEmptyList
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
@@ -13,7 +14,7 @@ class AggregatedExceptionTest extends AnyFunSuite {
 
   test("Test printStackTrace") {
     val ex = new AggregatedException(
-      Seq(
+      NonEmptyList.of(
         new RuntimeException("EX1"),
         new RuntimeException("EX2"),
         new RuntimeException("EX3")
@@ -25,7 +26,7 @@ class AggregatedExceptionTest extends AnyFunSuite {
 
   test("Test getStackTraces - Has size == 3") {
     val ex = new AggregatedException(
-      Seq(
+      NonEmptyList.of(
         new RuntimeException("EX1"),
         new RuntimeException("EX2"),
         new RuntimeException("EX3")
@@ -38,7 +39,7 @@ class AggregatedExceptionTest extends AnyFunSuite {
 
   test("Test getStackTrace - non Empty") {
     val ex = new AggregatedException(
-      Seq(
+      NonEmptyList.of(
         new RuntimeException("EX1"),
         new RuntimeException("EX2"),
         new RuntimeException("EX3")
@@ -50,7 +51,7 @@ class AggregatedExceptionTest extends AnyFunSuite {
 
   test("Test setStackTrace - should throw UnsupportedOperationException") {
     val ex = new AggregatedException(
-      Seq(
+      NonEmptyList.of(
         new RuntimeException("EX1"),
         new RuntimeException("EX2"),
         new RuntimeException("EX3")

--- a/src/test/scala/advxml/core/validate/exeptions/AggregatedExceptionTest.scala
+++ b/src/test/scala/advxml/core/validate/exeptions/AggregatedExceptionTest.scala
@@ -1,7 +1,7 @@
 package advxml.core.validate.exeptions
 
 import advxml.core.validate.exceptions.AggregatedException
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /**
   * Advxml
@@ -9,7 +9,7 @@ import org.scalatest.FunSuite
   *
   * @author geirolad
   */
-class AggregatedExceptionTest extends FunSuite {
+class AggregatedExceptionTest extends AnyFunSuite {
 
   test("Test printStackTrace") {
     val ex = new AggregatedException(

--- a/src/test/scala/advxml/instances/ValidationInstanceTest.scala
+++ b/src/test/scala/advxml/instances/ValidationInstanceTest.scala
@@ -1,12 +1,29 @@
 package advxml.instances
 
+import advxml.core.validate.{ThrowableNel, ValidatedEx}
+import cats.Eq
 import org.scalatest.funsuite.AnyFunSuite
+import org.typelevel.discipline.scalatest.Discipline
 
-class ValidationInstanceTest extends AnyFunSuite {
+class ValidationInstanceTest extends AnyFunSuite with Discipline {
 
-//  test("") {
-//
-//    import advxml.instances.validate.validatedNelMonadErrorThrowableInstance
-//    cats.laws.discipline.MonadErrorTests[ValidatedEx, Throwable].monadError.all
-//  }
+  import advxml.instances.validate._
+  import cats.implicits._
+  import cats.laws.discipline.arbitrary._
+
+  implicit val eqThrowable: Eq[Throwable] = Eq.allEqual
+
+  checkAll(
+    "MonadTests[ValidatedEx, Throwable]",
+    cats.laws.discipline
+      .MonadErrorTests[ValidatedEx, Throwable]
+      .monad[Int, Int, Int]
+  )
+
+  checkAll(
+    "MonadTests[ValidatedEx, ThrowableNel]",
+    cats.laws.discipline
+      .MonadErrorTests[ValidatedEx, ThrowableNel]
+      .monad[Int, Int, Int]
+  )
 }

--- a/src/test/scala/advxml/instances/ValidationInstanceTest.scala
+++ b/src/test/scala/advxml/instances/ValidationInstanceTest.scala
@@ -1,0 +1,12 @@
+package advxml.instances
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ValidationInstanceTest extends AnyFunSuite {
+
+//  test("") {
+//
+//    import advxml.instances.validate.validatedNelMonadErrorThrowableInstance
+//    cats.laws.discipline.MonadErrorTests[ValidatedEx, Throwable].monadError.all
+//  }
+}

--- a/src/test/scala/advxml/instances/XmlPredicateInstancesTest.scala
+++ b/src/test/scala/advxml/instances/XmlPredicateInstancesTest.scala
@@ -1,11 +1,11 @@
 package advxml.instances
 
 import advxml.core.transform.actions.XmlPredicate.XmlPredicate
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.{Document, Elem, Group}
 
-class XmlPredicateInstancesTest extends FunSuite {
+class XmlPredicateInstancesTest extends AnyFunSuite {
 
   import advxml.instances.transform.predicates._
 

--- a/src/test/scala/advxml/instances/XmlPredicateTest.scala
+++ b/src/test/scala/advxml/instances/XmlPredicateTest.scala
@@ -1,10 +1,10 @@
 package advxml.instances
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.{Elem, NodeSeq}
 
-class XmlPredicateTest extends FunSuite {
+class XmlPredicateTest extends AnyFunSuite {
 
   import advxml.instances.transform.predicates._
   import advxml.syntax.normalize._

--- a/src/test/scala/advxml/syntax/ConvertersSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/ConvertersSyntaxTest.scala
@@ -3,11 +3,11 @@ package advxml.syntax
 import advxml.core.convert.{Converter, PureConverter, ValidatedConverter}
 import advxml.core.validate.ValidatedEx
 import cats.data.Validated.Valid
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.{Success, Try}
 
-class ConvertersSyntaxTest extends FunSuite {
+class ConvertersSyntaxTest extends AnyFunSuite {
 
   import advxml.syntax.convert._
   import cats.instances.option._

--- a/src/test/scala/advxml/syntax/ModifiersTest.scala
+++ b/src/test/scala/advxml/syntax/ModifiersTest.scala
@@ -1,10 +1,10 @@
 package advxml.syntax
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.xml.Text
 
-class ModifiersTest extends WordSpec {
+class ModifiersTest extends AnyWordSpec {
 
   import advxml.instances.convert._
   import advxml.instances.transform.modifiers._

--- a/src/test/scala/advxml/syntax/NestedMapSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/NestedMapSyntaxTest.scala
@@ -1,14 +1,14 @@
 package advxml.syntax
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.{Success, Try}
 
-class NestedMapSyntaxTest extends FunSuite {
+class NestedMapSyntaxTest extends AnyFunSuite {
 
   import advxml.syntax.nestedMap._
-  import cats.instances.try_._
   import cats.instances.option._
+  import cats.instances.try_._
 
   test("Test nestedMap | Try[Option[String]]") {
     val strValue: Try[Option[String]] = Success(Some("1"))

--- a/src/test/scala/advxml/syntax/PredicateSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/PredicateSyntaxTest.scala
@@ -1,9 +1,9 @@
 package advxml.syntax
 
 import advxml.core.PredicateAsserts
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PredicateSyntaxTest extends FunSuite with PredicateAsserts {
+class PredicateSyntaxTest extends AnyFunSuite with PredicateAsserts {
 
   import advxml.syntax.predicate._
 

--- a/src/test/scala/advxml/syntax/TextConverterSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/TextConverterSyntaxTest.scala
@@ -1,6 +1,6 @@
 package advxml.syntax
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.Text
 
@@ -10,7 +10,7 @@ import scala.xml.Text
   *
   * @author geirolad
   */
-class TextConverterSyntaxTest extends FunSuite {
+class TextConverterSyntaxTest extends AnyFunSuite {
 
   import advxml.instances.convert._
   import advxml.syntax.convert._

--- a/src/test/scala/advxml/syntax/ValidationSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/ValidationSyntaxTest.scala
@@ -1,11 +1,11 @@
 package advxml.syntax
 
 import advxml.core.validate.{EitherEx, EitherNelEx, ValidatedExAsserts}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Try
 
-class ValidationSyntaxTest extends FunSuite with ValidatedExAsserts {
+class ValidationSyntaxTest extends AnyFunSuite with ValidatedExAsserts {
 
   import advxml.syntax.validate._
 

--- a/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
@@ -4,7 +4,7 @@ import advxml.core.convert.ValidatedConverter
 import advxml.core.convert.xml.{ModelToXml, XmlToModel}
 import advxml.core.validate.ValidatedEx
 import cats.data.Validated.Valid
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.Elem
 
@@ -14,7 +14,7 @@ import scala.xml.Elem
   *
   * @author geirolad
   */
-class XmlConverterSyntaxTest extends FunSuite {
+class XmlConverterSyntaxTest extends AnyFunSuite {
 
   import advxml.syntax.convert._
   import advxml.syntax.nestedMap._

--- a/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
@@ -1,6 +1,7 @@
 package advxml.syntax
 
-import advxml.core.convert.{ModelToXml, ValidatedConverter, XmlToModel}
+import advxml.core.convert.ValidatedConverter
+import advxml.core.convert.xml.{ModelToXml, XmlToModel}
 import advxml.core.validate.ValidatedEx
 import cats.data.Validated.Valid
 import org.scalatest.FunSuite

--- a/src/test/scala/advxml/syntax/XmlNormalizerSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlNormalizerSyntaxTest.scala
@@ -1,7 +1,8 @@
 package advxml.syntax
 
 import advxml.core.XmlNormalizerAsserts
-import org.scalatest.{Assertion, FunSuite}
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.xml.NodeSeq
 
@@ -11,7 +12,7 @@ import scala.xml.NodeSeq
   *
   * @author geirolad
   */
-class XmlNormalizerSyntaxTest extends FunSuite with XmlNormalizerAsserts {
+class XmlNormalizerSyntaxTest extends AnyFunSuite with XmlNormalizerAsserts {
 
   import advxml.syntax.normalize._
 

--- a/src/test/scala/advxml/syntax/XmlTransformerSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlTransformerSyntaxTest.scala
@@ -1,12 +1,12 @@
 package advxml.syntax
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Try
 import scala.xml.{Elem, NodeSeq}
 import scala.xml.transform.RuleTransformer
 
-class XmlTransformerSyntaxTest extends FunSuite {
+class XmlTransformerSyntaxTest extends AnyFunSuite {
 
   import advxml.instances.convert._
   import advxml.instances.transform._

--- a/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
@@ -1,6 +1,6 @@
 package advxml.syntax
 
-import org.scalatest.FeatureSpec
+import org.scalatest.featurespec.AnyFeatureSpec
 
 import scala.language.postfixOps
 import scala.util.Try
@@ -12,12 +12,12 @@ import scala.xml.NodeSeq
   *
   * @author geirolad
   */
-class XmlTraverserSyntaxTest extends FeatureSpec {
+class XmlTraverserSyntaxTest extends AnyFeatureSpec {
 
   import advxml.syntax.traverse.try_._
 
-  feature("XmlTraverseSyntaxTest: Read Attributes") {
-    scenario("Read optional attribute") {
+  Feature("XmlTraverseSyntaxTest: Read Attributes") {
+    Scenario("Read optional attribute") {
       val xml =
         <Employers>
           <Employee Name="David"/>
@@ -34,7 +34,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(age.get.isEmpty)
     }
 
-    scenario("Read required attribute") {
+    Scenario("Read required attribute") {
       val xml =
         <Employers>
           <Employee Name="David"/>
@@ -49,8 +49,8 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
     }
   }
 
-  feature("XmlTraverseSyntaxTest: Read Immediate Nodes") {
-    scenario("Read optional immediate nodes") {
+  Feature("XmlTraverseSyntaxTest: Read Immediate Nodes") {
+    Scenario("Read optional immediate nodes") {
       val xml =
         <Employers>
           <Employee Name="David">
@@ -71,7 +71,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(works.get.isEmpty)
     }
 
-    scenario("Read optional immediate nodes waterfall") {
+    Scenario("Read optional immediate nodes waterfall") {
       val xml =
         <Employers>
           <Employee Name="David">
@@ -96,7 +96,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(data.get.isEmpty)
     }
 
-    scenario("Read required immediate nodes") {
+    Scenario("Read required immediate nodes") {
       val xml =
         <Employers>
           <Employee Name="David">
@@ -114,7 +114,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(works.isFailure)
     }
 
-    scenario("Read required immediate nodes waterfall") {
+    Scenario("Read required immediate nodes waterfall") {
       val xml =
         <Employers>
           <Employee Name="David">
@@ -137,8 +137,8 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
     }
   }
 
-  feature("XmlTraverseSyntaxTest: Read nested Nodes") {
-    scenario("Read optional nested nodes") {
+  Feature("XmlTraverseSyntaxTest: Read nested Nodes") {
+    Scenario("Read optional nested nodes") {
       val xml =
         <Employers>
           <Employee Name="David">
@@ -159,7 +159,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(works.get.isEmpty)
     }
 
-    scenario("Read required nested nodes") {
+    Scenario("Read required nested nodes") {
       val xml =
         <Employers>
           <Employee Name="David">
@@ -178,8 +178,8 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
     }
   }
 
-  feature("XmlTraverseSyntaxTest: Read content") {
-    scenario("Read optional text") {
+  Feature("XmlTraverseSyntaxTest: Read content") {
+    Scenario("Read optional text") {
       val noteData = "This is a test"
       val xml =
         <Employers>
@@ -201,7 +201,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(works.get.isEmpty)
     }
 
-    scenario("Read optional text waterfall") {
+    Scenario("Read optional text waterfall") {
       val noteData = "This is a test"
       val xml =
         <Employers>
@@ -223,7 +223,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(works.get.isEmpty)
     }
 
-    scenario("Read required text") {
+    Scenario("Read required text") {
       val noteData = "This is a test"
       val xml =
         <Employers>
@@ -242,7 +242,7 @@ class XmlTraverserSyntaxTest extends FeatureSpec {
       assert(works.isFailure)
     }
 
-    scenario("Read required text waterfall") {
+    Scenario("Read required text waterfall") {
       val noteData = "This is a test"
       val xml =
         <Employers>

--- a/src/test/scala/advxml/test/generators/XmlGenerator.scala
+++ b/src/test/scala/advxml/test/generators/XmlGenerator.scala
@@ -12,6 +12,8 @@ import scala.xml._
   */
 object XmlGenerator {
 
+  lazy val xmlNodeSelectorGenerator: Node => Gen[NodeSeq] = elem => Gen.oneOf(elem.descendant).filter(_ != elem)
+
   def genStr(size: Int): Gen[String] = Gen.listOfN(size, Gen.alphaChar).map(_.mkString)
 
   def attrsGenerator(maxSize: Int, nameMaxSize: Int): Gen[Map[String, String]] = {
@@ -24,7 +26,6 @@ object XmlGenerator {
       map <- Gen.mapOfN(n, kvGen)
     } yield map
   }
-  lazy val xmlNodeSelectorGenerator: Node => Gen[NodeSeq] = elem => Gen.oneOf(elem.descendant).filter(_ != elem)
 
   def xmlNodeGenerator(maxLevel: Int, level: Int = 0): Gen[BasicXmlNode] =
     for {


### PR DESCRIPTION
## Changes
- Remove TextConverter type alias.
- Refactoring XmlConverter.
- Add test for custom RuleTransformer
- Update "org.scalatest" %% "scalatest" to 3.1.0
- Add Cats Laws for ValidatedEx monad error instance.