### PR TITLE
Refactoring XmlTraverser

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.0
+version = 2.4.2
 style = defaultWithAlign
 encoding = "UTF-8"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Advxml
 
-[![Build Status](https://img.shields.io/travis/geirolz/advxml/master)](https://travis-ci.org/geirolz/advxml)
+[![Build Status](https://img.shields.io/travis/com/geirolz/advxml/master)](https://travis-ci.org/geirolz/advxml)
 [![codecov](https://img.shields.io/codecov/c/github/geirolz/advxml)](https://codecov.io/gh/geirolz/advxml)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/db3274b55e0c4031803afb45f58d4413)](https://www.codacy.com/manual/david.geirola/advxml?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=geirolz/advxml&amp;utm_campaign=Badge_Grade)
 [![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/com.github.geirolz/advxml_2.13?server=https%3A%2F%2Foss.sonatype.org)](https://mvnrepository.com/artifact/com.github.geirolz/advxml)

--- a/docs/Convert.md
+++ b/docs/Convert.md
@@ -13,26 +13,56 @@ errors.
     
 #### Example(XML to Model)
 ```scala
-    //TODO
+  import advxml.implicits._
+  import advxml.core.convert.ValidatedConverter
+  import advxml.core.validate.ValidatedEx
+  import advxml.core.convert.xml.XmlToModel
+  import advxml.syntax.nestedMap._
+  import advxml.syntax.traverse.validated._
+  import scala.xml._
+  import cats.data.Kleisli
+  import cats.implicits._
+  import cats.data.Validated.Valid
+
+  case class Person(name: String, surname: String, age: Option[Int])
+
+  implicit val converter: XmlToModel[Elem, Person] = ValidatedConverter.of(x => {
+    (
+      x \@! "Name",
+      x \@! "Surname",
+      x \@? "Age" nestedMap (_.toInt)
+    ).mapN(Person)
+  })
+
+  val xml = <Person Name="Matteo" Surname="Bianchi"/>
+  val res: ValidatedEx[Person] = xml.as[Person]
+
+  assert(res.map(_.name) == Valid("Matteo"))
+  assert(res.map(_.surname) == Valid("Bianchi"))
 ```
 
 #### Example(Model to XML) 
 ```scala
-    import advxml.implicits._
-    import advxml.core.validate.ValidatedEx
-    import advxml.core.convert.xml.ModelToXml
-    import scala.xml._
-    import cats.data.Kleisli
-    import cats.implicits._
-    import cats.data.Validated.Valid
+  import advxml.implicits._
+  import advxml.core.validate.ValidatedEx
+  import advxml.core.convert.ValidatedConverter
+  import advxml.core.convert.xml.ModelToXml
+  import scala.xml._
+  import cats.data.Kleisli
+  import cats.implicits._
+  import cats.data.Validated.Valid
 
   case class Person(name: String, surname: String, age: Option[Int])
-  
-  implicit val converter: ModelToXml[Person, Elem] = Kleisli(x =>
-    Valid {
-      <Person Name={x.name} Surname={x.surname} Age={x.age.map(_.toString).getOrElse("")}/>
-    })
-  
+
+  implicit val converter: ModelToXml[Person, Elem] = ValidatedConverter.of(
+    x =>
+      Valid(
+        <Person Name={x.name} Surname={x.surname} Age={x.age.map(_.toString).getOrElse("")}/>
+      )
+  )
+
   val p = Person("Matteo", "Bianchi", Some(23))
   val res: ValidatedEx[Elem] = p.as[Elem]
+
+  assert(res == Valid(<Person Name="Matteo" Surname="Bianchi" Age="23"/>))
 ```

--- a/docs/Convert.md
+++ b/docs/Convert.md
@@ -1,7 +1,7 @@
 ### Convert <a name="Convert"></a>
 This feature provides several conversion utility.
 The main utility are:
-- ValidatedConverter: convert A to ValidatedEx[B]  
+- ValidatedConverter: convert A to ValidatedNelEx[B]  
 - TextConverter: convert object to xml text
 - XmlConverter: convert object to xml and viceversa
    
@@ -13,16 +13,17 @@ errors.
     
 #### Example(XML to Model)
 ```scala
-  import advxml.implicits._
   import advxml.core.convert.ValidatedConverter
-  import advxml.core.validate.ValidatedEx
-  import advxml.core.convert.xml.XmlToModel
-  import advxml.syntax.nestedMap._
-  import advxml.syntax.traverse.validated._
-  import scala.xml._
-  import cats.data.Kleisli
-  import cats.implicits._
+  import advxml.core.convert.xml.{ModelToXml, XmlToModel}
+  import advxml.core.validate.ValidatedNelEx
   import cats.data.Validated.Valid
+  import scala.xml.Elem
+
+  import advxml.syntax.convert._
+  import advxml.syntax.traverse.validated._
+  import cats.syntax.all._
+  import cats.instances.option._
+  import advxml.instances.validate._
 
   case class Person(name: String, surname: String, age: Option[Int])
 
@@ -30,12 +31,12 @@ errors.
     (
       x \@! "Name",
       x \@! "Surname",
-      x \@? "Age" nestedMap (_.toInt)
+      x.\@?("Age").map(_.toInt).valid
     ).mapN(Person)
   })
 
   val xml = <Person Name="Matteo" Surname="Bianchi"/>
-  val res: ValidatedEx[Person] = xml.as[Person]
+  val res: ValidatedNelEx[Person] = xml.as[Person]
 
   assert(res.map(_.name) == Valid("Matteo"))
   assert(res.map(_.surname) == Valid("Bianchi"))
@@ -43,14 +44,17 @@ errors.
 
 #### Example(Model to XML) 
 ```scala
-  import advxml.implicits._
-  import advxml.core.validate.ValidatedEx
   import advxml.core.convert.ValidatedConverter
-  import advxml.core.convert.xml.ModelToXml
-  import scala.xml._
-  import cats.data.Kleisli
-  import cats.implicits._
+  import advxml.core.convert.xml.{ModelToXml, XmlToModel}
+  import advxml.core.validate.ValidatedNelEx
   import cats.data.Validated.Valid
+  import scala.xml.Elem
+
+  import advxml.syntax.convert._
+  import advxml.syntax.traverse.validated._
+  import cats.syntax.all._
+  import cats.instances.option._
+  import advxml.instances.validate._
 
   case class Person(name: String, surname: String, age: Option[Int])
 
@@ -62,7 +66,7 @@ errors.
   )
 
   val p = Person("Matteo", "Bianchi", Some(23))
-  val res: ValidatedEx[Elem] = p.as[Elem]
+  val res: ValidatedNelEx[Elem] = p.as[Elem]
 
   assert(res == Valid(<Person Name="Matteo" Surname="Bianchi" Age="23"/>))
 ```

--- a/docs/Normalize.md
+++ b/docs/Normalize.md
@@ -1,2 +1,29 @@
 # Normalize
-_Work in progress_
+Normalization feature allows to collapse empty nodes and trim texts.
+
+You can use directly `XmlNormalizer` or importing `advxml.syntax.normalize._` you can have normalization 
+methods onto `NodeSeq` instance.
+ 
+#### Example
+```scala   
+    import scala.xml.{Elem, NodeSeq}
+    import advxml.core.XmlNormalizer
+
+    val elem: Elem = <bar><foo></foo></bar>
+    val result: NodeSeq = XmlNormalizer.normalize(elem)
+    //result will be 
+    //<bar><foo/></bar>
+```
+
+#### Example with syntax
+```scala
+    import scala.xml.{Elem, NodeSeq}
+    import advxml.syntax.normalize._
+
+    val elem: Elem = <bar><foo></foo></bar>
+    val result:NodeSeq = elem.normalize
+    //result will be 
+    //<bar><foo/></bar>
+```
+
+

--- a/docs/Traverse.md
+++ b/docs/Traverse.md
@@ -2,22 +2,24 @@
 This feature allow users read/obtain node(s) or attributes.
 
 This feature core is written with tagless final and all methods 
-returns an output value wrapped in `F[G[_]]`, where:
-- `_F[_]_` is the main type, all result is wrapped in F.
-- `G[_]` is the result of the read.
+returns an output value wrapped in `F[_]`.
 
 You can import specific syntax using *traverse* object provided by *instances*, 
 inside it you can find multiple objects containing all implicits for the required syntax.
 
 At the moment are available supports for:
 - try
+- option
 - either
-- validatedEx(_cats ValidatedNel[Throwble]_)
+- validated(_cats ValidatedNel[Throwble]_)
      
 ## Syntax
 - _?_ means optional things
 - _!_ means mandatory things
 
+Mandatory syntax require  `MonadEx` in the scope.
+Optional syntax require `Alternative` and `Monad` in the scope.   
+     
 So the syntax is the same of standard XML library but you can postfix *?* or *!* to method name in order to
 handle the presence of what you are looking for.
 
@@ -35,14 +37,18 @@ handle the presence of what you are looking for.
 
 *Text*
 - _?_ optional text
+- _|?|_ optional trimmed text
 - _!_ mandatory text
+- _|!|_ mandatory trimmed text
 
 #### Example
 ```scala
     import advxml.syntax.traverse.try_._
     import scala.xml._
     import scala.util.Try
-    
+    import cats.instances.try_._
+    import cats.instances.option._
+
     val doc: Elem = 
     <Persons>
       <Person Name="Mimmo">
@@ -56,19 +62,23 @@ handle the presence of what you are looking for.
 
     //Nodes
     val mandatoryNode: Try[NodeSeq] = doc \ "Person" \! "Cars"
-    val optionalNode: Try[Option[NodeSeq]] = doc \ "Person" \? "Cars"
+    val optionalNode: Option[NodeSeq] = doc \ "Person" \? "Cars"
     
     //Nested nodes
     val mandatoryNestedNode: Try[NodeSeq] = doc \ "Person" \\! "Cars"
-    val optionalNestedNode: Try[Option[NodeSeq]] = doc \ "Person" \\? "Cars"
+    val optionalNestedNode: Option[NodeSeq] = doc \ "Person" \\? "Cars"
 
     //Attributes
     val mandatoryAttr: Try[String] = doc \ "Person" \ "Cars" \ "Car" \@! "Brand"
-    val optionalAttr: Try[Option[String]] = doc \ "Person" \ "Cars" \ "Car" \@? "Brand"
+    val optionalAttr: Option[String] = doc \ "Person" \ "Cars" \ "Car" \@? "Brand"
 
     //Text
     val mandatoryText: Try[String] = doc \ "Person" \ "Cars" \ "Car" \ "Price" !
-    val optionalText: Try[Option[String]] = doc \ "Person" \ "Cars" \ "Car" \ "Price" ?
+    val optionalText: Option[String] = doc \ "Person" \ "Cars" \ "Car" \ "Price" ?
+
+    //Trimmed Text
+    val mandatoryTrimmedText: Try[String] = doc \ "Person" \ "Cars" \ "Car" \ "Price" |!|
+    val optionalTrimmedText: Option[String] = doc \ "Person" \ "Cars" \ "Car" \ "Price" |?|
 ```
 
 ## Nested
@@ -79,6 +89,8 @@ You can even traverse wrapped `NodeSeq` with the same syntax
     import advxml.instances.transform._
     import scala.xml._
     import scala.util.Try
+    import cats.instances.try_._
+    import cats.instances.option._
     
     val doc: Elem = 
     <Persons>

--- a/examples/features/transform/TransformWs.sc
+++ b/examples/features/transform/TransformWs.sc
@@ -21,10 +21,11 @@ val document =
     </Order>
   </Orders>
 
-
-val result: Try[NodeSeq] = document.transform((
-  (root \ "Order" filter attrs(("Id", _ == "1")))
-    \ "OrderLines"
-    \ "OrderLine" filter attrs("Id" -> (_ == "2"))
-) ==> Append(<Node>new node!</Node>))
+val result: Try[NodeSeq] = document.transform(
+    (
+      (root \ "Order" filter attrs(("Id", _ == "1")))
+      \ "OrderLines"
+      \ "OrderLine" filter attrs("Id" -> (_ == "2"))
+    ) ==> Append(<Node>new node!</Node>)
+  )
 

--- a/examples/features/traverse/TraverseWs.sc
+++ b/examples/features/traverse/TraverseWs.sc
@@ -1,10 +1,7 @@
-import advxml.syntax.nestedMap._
 import advxml.syntax.traverse.try_._
-
-import scala.util.Try
-import scala.xml.NodeSeq
-import cats.instances.try_._
 import cats.instances.option._
+
+import scala.xml.NodeSeq
 
 //TODO: TO Fix location
 import advxml.instances.transform.predicates._
@@ -25,5 +22,5 @@ val document =
     </Order>
   </Orders>
 
-val order2Opt : Try[Option[NodeSeq]] = (document \? "Order")
-  .nestedMap(_.filter(attrs(("Id", _ == "2"))))
+val order2Opt: Option[NodeSeq] = (document \? "Order")
+    .map(_.filter(attrs(("Id", _ == "2"))))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,13 +11,13 @@ object Dependencies {
   lazy val all: Seq[ModuleID] = Seq(
     //SCALA
     "org.typelevel" %% "cats-core" % "2.1.1" cross CrossVersion.binary,
-    "org.scalactic" %% "scalactic" % "3.0.8" cross CrossVersion.binary,
+    "org.scalactic" %% "scalactic" % "3.1.1" cross CrossVersion.binary,
     //XML
     "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1" cross CrossVersion.binary,
     //TEST
     "org.typelevel" %% "discipline-scalatest" % "1.0.0-RC2" % Test,
     "org.typelevel" %% "cats-laws" % "2.1.1" % Test cross CrossVersion.binary,
-    "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,
+    "org.scalatest" %% "scalatest" % "3.1.1" % Test cross CrossVersion.binary,
     "org.scalacheck" %% "scalacheck" % "1.14.3" % Test cross CrossVersion.binary
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,14 +10,13 @@ object Dependencies {
 
   lazy val all: Seq[ModuleID] = Seq(
     //SCALA
-    "org.typelevel" %% "cats-core" % "2.1.0" cross CrossVersion.binary,
+    "org.typelevel" %% "cats-core" % "2.1.1" cross CrossVersion.binary,
     "org.scalactic" %% "scalactic" % "3.0.8" cross CrossVersion.binary,
     //XML
     "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1" cross CrossVersion.binary,
     //TEST
     "org.typelevel" %% "discipline-scalatest" % "1.0.0-RC2" % Test,
-    "org.typelevel" %% "cats-laws" % "2.1.0" % Test cross CrossVersion.binary,
-    "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,
+    "org.typelevel" %% "cats-laws" % "2.1.1" % Test cross CrossVersion.binary,
     "org.scalatest" %% "scalatest" % "3.1.0" % Test cross CrossVersion.binary,
     "org.scalacheck" %% "scalacheck" % "1.14.3" % Test cross CrossVersion.binary
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     //XML
     "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1" cross CrossVersion.binary,
     //TEST
-    "org.typelevel" %% "discipline-scalatest" % "1.0.0-RC2" % Test,
+    "org.typelevel" %% "discipline-scalatest" % "1.0.1" % Test,
     "org.typelevel" %% "cats-laws" % "2.1.1" % Test cross CrossVersion.binary,
     "org.scalatest" %% "scalatest" % "3.1.1" % Test cross CrossVersion.binary,
     "org.scalacheck" %% "scalacheck" % "1.14.3" % Test cross CrossVersion.binary

--- a/src/main/scala/advxml/core/convert/Converter.scala
+++ b/src/main/scala/advxml/core/convert/Converter.scala
@@ -1,6 +1,6 @@
 package advxml.core.convert
 
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 import cats.{Applicative, Id}
 import cats.data.Kleisli
 
@@ -71,4 +71,4 @@ private[convert] sealed abstract class FixedWrapperConverter[F[_]: Applicative, 
 }
 
 object PureConverter extends FixedWrapperConverter[Id, PureConverter]
-object ValidatedConverter extends FixedWrapperConverter[ValidatedEx, ValidatedConverter]
+object ValidatedConverter extends FixedWrapperConverter[ValidatedNelEx, ValidatedConverter]

--- a/src/main/scala/advxml/core/convert/package.scala
+++ b/src/main/scala/advxml/core/convert/package.scala
@@ -1,6 +1,6 @@
 package advxml.core
 
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 import cats.Id
 import cats.data.Kleisli
 
@@ -31,10 +31,10 @@ package object convert {
   /**
     * Represents a function `A => ValidatedEx[B]` to simplify method and class signatures.
     * Converter to easily transform an object of type `A` to another object of type `B`.
-    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors.
+    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedNelEx]] in order to handle the errors.
     *
     * @tparam A Contravariant input object type
     * @tparam B Output object type
     */
-  type ValidatedConverter[-A, B] = Converter[ValidatedEx, A, B]
+  type ValidatedConverter[-A, B] = Converter[ValidatedNelEx, A, B]
 }

--- a/src/main/scala/advxml/core/convert/xml/XmlConverter.scala
+++ b/src/main/scala/advxml/core/convert/xml/XmlConverter.scala
@@ -2,7 +2,7 @@ package advxml.core.convert.xml
 
 import advxml.core.convert
 import advxml.core.convert.ValidatedConverter
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 
 import scala.annotation.implicitNotFound
 import scala.xml.NodeSeq
@@ -17,10 +17,10 @@ object XmlConverter {
     * @see [[ValidatedConverter]] for further information.
     * @tparam X Contravariant input xml model type
     * @tparam O Object output type
-    * @return [[advxml.core.validate.ValidatedEx]] instance that, if on success case contains `X` instance.
+    * @return [[advxml.core.validate.ValidatedNelEx]] instance that, if on success case contains `X` instance.
     */
   @implicitNotFound("Missing XmlToModel to transform ${X} into ValidatedEx[${O}]")
-  def asModel[X <: NodeSeq: XmlToModel[*, O], O](xml: X): ValidatedEx[O] = ValidatedConverter[X, O].run(xml)
+  def asModel[X <: NodeSeq: XmlToModel[*, O], O](xml: X): ValidatedNelEx[O] = ValidatedConverter[X, O].run(xml)
 
   /**
     * Syntactic sugar to convert a `X` instance into `O` using an implicit [[XmlToModel]] instance.
@@ -33,9 +33,9 @@ object XmlConverter {
     * @see [[ValidatedConverter]] for further information.
     * @tparam O Contravariant input model type
     * @tparam X Output xml type
-    * @return [[advxml.core.validate.ValidatedEx]] instance that, if on success case contains `O` instance.
+    * @return [[advxml.core.validate.ValidatedNelEx]] instance that, if on success case contains `O` instance.
     */
   @implicitNotFound("Missing ModelToXml to transform ${O} into ValidatedEx[${X}]")
-  def asXml[O: convert.xml.ModelToXml[*, X], X <: NodeSeq](model: O): ValidatedEx[X] =
+  def asXml[O: convert.xml.ModelToXml[*, X], X <: NodeSeq](model: O): ValidatedNelEx[X] =
     ValidatedConverter[O, X].run(model)
 }

--- a/src/main/scala/advxml/core/convert/xml/xml.scala
+++ b/src/main/scala/advxml/core/convert/xml/xml.scala
@@ -7,7 +7,7 @@ package object xml {
   /**
     * Represents a function `O => ValidatedEx[NodeSeq]` to simplify method and class signatures.
     * This function transform a model of type `O` to standard scala-xml library `NodeSeq`, in this case `X`.
-    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors
+    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedNelEx]] in order to handle the errors
     *
     * @see [[ValidatedConverter]] for further information.
     * @tparam O Contravariant input model type
@@ -18,7 +18,7 @@ package object xml {
   /**
     * Represents a function `NodeSeq => ValidatedEx[O]` to simplify method and class signatures.
     * This function transform xml model of type `X`, from standard scala-xml library, into a model of type `O`
-    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedEx]] in order to handle the errors
+    * Because the conversion can fail the output is wrapped into cats [[advxml.core.validate.ValidatedNelEx]] in order to handle the errors
     *
     * @see [[ValidatedConverter]] for further information.
     * @tparam X Contravariant input xml model, type constraint ensures that `X` is a subtype of scala-xml `NodeSeq`

--- a/src/main/scala/advxml/core/validate/ValidatedNelEx.scala
+++ b/src/main/scala/advxml/core/validate/ValidatedNelEx.scala
@@ -7,35 +7,35 @@ import cats.data.{NonEmptyList, Validated}
 
 import scala.util.Try
 
-object ValidatedEx {
+object ValidatedNelEx {
 
-  def fromTry[A](t: Try[A]): ValidatedEx[A] =
+  def fromTry[A](t: Try[A]): ValidatedNelEx[A] =
     t.fold(e => Invalid(NonEmptyList.of(e)), Valid(_))
 
-  def fromEither[A](e: EitherEx[A]): ValidatedEx[A] =
+  def fromEither[A](e: EitherEx[A]): ValidatedNelEx[A] =
     fromEitherNel(e.left.map(NonEmptyList.one))
 
-  def fromEitherNel[A](e: EitherNelEx[A]): ValidatedEx[A] =
+  def fromEitherNel[A](e: EitherNelEx[A]): ValidatedNelEx[A] =
     Validated.fromEither(e)
 
-  def fromOption[A](o: Option[A], ifNone: => Throwable): ValidatedEx[A] =
+  def fromOption[A](o: Option[A], ifNone: => Throwable): ValidatedNelEx[A] =
     Validated.fromOption(o, NonEmptyList.one(ifNone))
 
-  def transformE[F[_], A](validated: ValidatedEx[A])(implicit F: MonadEx[F]): F[A] = {
+  def transformE[F[_], A](validated: ValidatedNelEx[A])(implicit F: MonadEx[F]): F[A] = {
     validated match {
       case Valid(value) => F.pure(value)
       case Invalid(exs) => F.raiseError(new AggregatedException(exs))
     }
   }
 
-  def transformNE[F[_], A](validated: ValidatedEx[A])(implicit F: MonadNelEx[F]): F[A] = {
+  def transformNE[F[_], A](validated: ValidatedNelEx[A])(implicit F: MonadNelEx[F]): F[A] = {
     validated match {
       case Valid(value) => F.pure(value)
       case Invalid(exs) => F.raiseError(exs)
     }
   }
 
-  def transformA[F[_], A](validated: ValidatedEx[A])(implicit F: Alternative[F]): F[A] = {
+  def transformA[F[_], A](validated: ValidatedNelEx[A])(implicit F: Alternative[F]): F[A] = {
     validated match {
       case Valid(a)   => F.pure(a)
       case Invalid(_) => F.empty

--- a/src/main/scala/advxml/core/validate/exceptions/AggregatedException.scala
+++ b/src/main/scala/advxml/core/validate/exceptions/AggregatedException.scala
@@ -35,6 +35,7 @@ class AggregatedException(val exceptions: NonEmptyList[Throwable])
   @Deprecated
   override def getStackTrace: Array[StackTraceElement] = super.getStackTrace
 
+  /** @deprecated This method is not supported by [[AggregatedException]] */
   @Deprecated
   override def setStackTrace(stackTrace: Array[StackTraceElement]): Unit =
     throw new UnsupportedOperationException

--- a/src/main/scala/advxml/core/validate/package.scala
+++ b/src/main/scala/advxml/core/validate/package.scala
@@ -5,12 +5,13 @@ import cats.MonadError
 
 package object validate {
   // format: off
-  type \/[+A, +B]           = Either[A, B]
+  @deprecated(message = "This type alias will be removed in the future releases, please use ValidatedNelEx instead.", since = "2.2.0")
+  type ValidatedEx[+T]      = ValidatedNelEx[T]
   type MonadEx[F[_]]        = MonadError[F, Throwable]
   type MonadNelEx[F[_]]     = MonadError[F, ThrowableNel]
   type EitherEx[+T]         = Either[Throwable, T]
   type EitherNelEx[+T]      = EitherNel[Throwable, T]
-  type ValidatedEx[+T]      = ValidatedNel[Throwable, T]
+  type ValidatedNelEx[+T]   = ValidatedNel[Throwable, T]
   type ThrowableNel         = NonEmptyList[Throwable]
   // format: on
 

--- a/src/main/scala/advxml/instances/XmlModifierInstances.scala
+++ b/src/main/scala/advxml/instances/XmlModifierInstances.scala
@@ -66,8 +66,8 @@ private[instances] trait XmlModifierInstances {
         case e: Elem =>
           F.pure[NodeSeq](
             e.copy(
-              attributes = (d +: ds).foldRight(e.attributes)(
-                (data, metadata) => new UnprefixedAttribute(data.key, data.value, metadata)
+              attributes = (d +: ds).foldRight(e.attributes)((data, metadata) =>
+                new UnprefixedAttribute(data.key, data.value, metadata)
               )
             )
           )

--- a/src/main/scala/advxml/instances/XmlPredicateInstances.scala
+++ b/src/main/scala/advxml/instances/XmlPredicateInstances.scala
@@ -49,8 +49,9 @@ private[instances] trait XmlPredicateInstances {
   }
 
   def hasImmediateChild(label: String, predicate: XmlPredicate = alwaysTrue): XmlPredicate = { xml =>
-    import advxml.syntax.traverse.try_._
-    (xml \? label).toOption.flatten.fold(false)(_.exists(predicate))
+    import cats.instances.option._
+    import advxml.syntax.traverse.option._
+    (xml \? label).fold(false)(_.exists(predicate))
   }
 
   def strictEqualsTo(ns: NodeSeq): XmlPredicate =
@@ -58,6 +59,5 @@ private[instances] trait XmlPredicateInstances {
       (ns, that) match {
         case (e1: Node, e2: Node)         => e1 strict_== e2
         case (ns1: NodeSeq, ns2: NodeSeq) => ns1 strict_== ns2
-        case _                            => false
       }
 }

--- a/src/main/scala/advxml/syntax/AllSyntax.scala
+++ b/src/main/scala/advxml/syntax/AllSyntax.scala
@@ -2,7 +2,7 @@ package advxml.syntax
 
 private[advxml] trait AllSyntax
     extends XmlTransformerSyntax
-    with XmlTraverserAbstractSyntax
+    with XmlTraverserSyntax
     with XmlNormalizerSyntax
     with ConvertersSyntax
     with ValidationSyntax

--- a/src/main/scala/advxml/syntax/ConvertersSyntax.scala
+++ b/src/main/scala/advxml/syntax/ConvertersSyntax.scala
@@ -1,7 +1,7 @@
 package advxml.syntax
 
 import advxml.core.convert.{PureConverter, _}
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 import cats.{Applicative, Id, Monad}
 import cats.implicits._
 
@@ -45,7 +45,7 @@ private[syntax] trait ConvertersSyntax {
       * @see [[Converter]] for further information.
       */
     @implicitNotFound("Missing ValidatedConverter to transform object into ValidatedConverter[${B}].")
-    def as[B](implicit F: ValidatedConverter[A, B], i1: DummyImplicit, i2: DummyImplicit): ValidatedEx[B] =
+    def as[B](implicit F: ValidatedConverter[A, B], i1: DummyImplicit, i2: DummyImplicit): ValidatedNelEx[B] =
       ValidatedConverter[A, B].run(a)
   }
 }

--- a/src/main/scala/advxml/syntax/ValidationSyntax.scala
+++ b/src/main/scala/advxml/syntax/ValidationSyntax.scala
@@ -8,30 +8,30 @@ import scala.util.Try
 private[syntax] trait ValidationSyntax {
 
   implicit class ValidatedExTryOps[A](t: Try[A]) {
-    def toValidatedEx: ValidatedEx[A] = ValidatedEx.fromTry(t)
+    def toValidatedEx: ValidatedNelEx[A] = ValidatedNelEx.fromTry(t)
   }
 
   implicit class ValidatedExEitherOps[A](e: EitherEx[A]) {
-    def toValidatedEx: ValidatedEx[A] = ValidatedEx.fromEither(e)
+    def toValidatedEx: ValidatedNelEx[A] = ValidatedNelEx.fromEither(e)
   }
 
   implicit class ValidatedExEitherNelOps[A](e: EitherNelEx[A]) {
-    def toValidatedEx: ValidatedEx[A] = ValidatedEx.fromEitherNel(e)
+    def toValidatedEx: ValidatedNelEx[A] = ValidatedNelEx.fromEitherNel(e)
   }
 
   implicit class ValidatedExOptionOps[A](e: Option[A]) {
-    def toValidatedEx(ifNone: => Throwable): ValidatedEx[A] = ValidatedEx.fromOption(e, ifNone)
+    def toValidatedEx(ifNone: => Throwable): ValidatedNelEx[A] = ValidatedNelEx.fromOption(e, ifNone)
   }
 
-  implicit class ValidatedExOps[A](validated: ValidatedEx[A]) {
+  implicit class ValidatedExOps[A](validated: ValidatedNelEx[A]) {
 
     def transformE[F[_]](implicit F: MonadEx[F]): F[A] =
-      ValidatedEx.transformE[F, A](validated)(F)
+      ValidatedNelEx.transformE[F, A](validated)(F)
 
     def transformNE[F[_]](implicit F: MonadNelEx[F]): F[A] =
-      ValidatedEx.transformNE[F, A](validated)(F)
+      ValidatedNelEx.transformNE[F, A](validated)(F)
 
     def transformA[F[_]](implicit F: Alternative[F]): F[A] =
-      ValidatedEx.transformA[F, A](validated)(F)
+      ValidatedNelEx.transformA[F, A](validated)(F)
   }
 }

--- a/src/main/scala/advxml/syntax/XmlNormalizerSyntax.scala
+++ b/src/main/scala/advxml/syntax/XmlNormalizerSyntax.scala
@@ -9,7 +9,10 @@ import scala.xml.NodeSeq
 private[syntax] trait XmlNormalizerSyntax {
 
   implicit def streamlinedXmlNormalizedEquality[T <: NodeSeq]: Equality[T] =
-    (a: T, b: Any) => Try(XmlNormalizer.normalizedEquals(a, b.asInstanceOf[NodeSeq])).getOrElse(false)
+    (a: T, b: Any) =>
+      Try(
+        XmlNormalizer.normalizedEquals(a, b.asInstanceOf[NodeSeq])
+      ).getOrElse(false)
 
   implicit class NodeSeqNormalizationAndEqualityOps(ns: NodeSeq) {
 

--- a/src/main/scala/advxml/syntax/package.scala
+++ b/src/main/scala/advxml/syntax/package.scala
@@ -1,5 +1,9 @@
 package advxml
 
+import advxml.core.validate.{EitherEx, ValidatedNelEx}
+
+import scala.util.Try
+
 /*
  * In order to keep project clean keep in mind the following rules:
  * - Each feature can provide a trait that contains ONLY the syntax, NO public object or explicit public class.
@@ -29,10 +33,11 @@ package object syntax {
   object convert      extends ConvertersSyntax
   object normalize    extends XmlNormalizerSyntax
   object validate     extends ValidationSyntax
-  object traverse     extends XmlTraverserAbstractSyntax{
-    object try_       extends XmlTraverserTrySyntax
-    object either     extends XmlTraverserEitherSyntax
-    object validated  extends XmlTraverserValidatedSyntax
+  object traverse     extends XmlTraverserSyntax{
+    object try_       extends XmlTraverserSyntaxSpecified[Try, Option]
+    object option     extends XmlTraverserSyntaxSpecified[Option, Option]
+    object either     extends XmlTraverserSyntaxSpecified[EitherEx, Option]
+    object validated  extends XmlTraverserSyntaxSpecified[ValidatedNelEx, Option]
   }
   object predicate    extends PredicateSyntax
   object nestedMap    extends NestedMapSyntax

--- a/src/test/scala/advxml/core/XmlTraverserTest.scala
+++ b/src/test/scala/advxml/core/XmlTraverserTest.scala
@@ -25,7 +25,7 @@ class XmlTraverseTest extends AnyFeatureSpec with XmlTraverserContractAsserts {
       mandatory.assertText(XmlTraverser.mandatory[Try].text(_))
     }
     Scenario("|!|") {
-      mandatory.assertText(XmlTraverser.mandatory[Try].trimmedText(_))
+      mandatory.assertTrimmedText(XmlTraverser.mandatory[Try].trimmedText(_))
     }
   }
 
@@ -47,7 +47,7 @@ class XmlTraverseTest extends AnyFeatureSpec with XmlTraverserContractAsserts {
       optional.assertText(XmlTraverser.optional[Option].text(_))
     }
     Scenario("|?|") {
-      optional.assertText(XmlTraverser.optional[Option].trimmedText(_))
+      optional.assertTrimmedText(XmlTraverser.optional[Option].trimmedText(_))
     }
   }
 }

--- a/src/test/scala/advxml/core/XmlTraverserTest.scala
+++ b/src/test/scala/advxml/core/XmlTraverserTest.scala
@@ -1,0 +1,105 @@
+package advxml.core
+
+import org.scalatest.featurespec.AnyFeatureSpec
+
+import scala.util.Try
+import scala.xml.{Elem, NodeSeq}
+
+class XmlTraverseTest extends AnyFeatureSpec with XmlTraverserContractAsserts {
+
+  Feature("XmlTraverse.Mandatory") {
+
+    import cats.instances.try_._
+
+    Scenario("\\!") {
+      mandatory.assertImmediateChild((nodeName, doc) => XmlTraverser.mandatory[Try].immediateChildren(doc, nodeName))
+    }
+
+    Scenario("\\\\!") {
+      mandatory.assertChildren((nodeName, doc) => XmlTraverser.mandatory[Try].children(doc, nodeName))
+    }
+    Scenario("\\@!") {
+      mandatory.assertAttribute((attrName, doc) => XmlTraverser.mandatory[Try].attr(doc, attrName))
+    }
+    Scenario("!") {
+      mandatory.assertText(XmlTraverser.mandatory[Try].text(_))
+    }
+    Scenario("|!|") {
+      mandatory.assertText(XmlTraverser.mandatory[Try].trimmedText(_))
+    }
+  }
+
+  Feature("XmlTraverse.Optional") {
+
+    import cats.instances.option._
+
+    Scenario("\\?") {
+      optional.assertImmediateChild((nodeName, doc) => XmlTraverser.optional[Option].immediateChildren(doc, nodeName))
+    }
+
+    Scenario("\\\\?") {
+      optional.assertChildren((nodeName, doc) => XmlTraverser.optional[Option].children(doc, nodeName))
+    }
+    Scenario("\\@?") {
+      optional.assertAttribute((attrName, doc) => XmlTraverser.optional[Option].attr(doc, attrName))
+    }
+    Scenario("?") {
+      optional.assertText(XmlTraverser.optional[Option].text(_))
+    }
+    Scenario("|?|") {
+      optional.assertText(XmlTraverser.optional[Option].trimmedText(_))
+    }
+  }
+}
+
+//Contract test
+private[advxml] trait XmlTraverserContractAsserts {
+
+  import advxml.syntax.normalize._
+
+  sealed trait TypedXmlTraverseAsserts[F[_]] {
+
+    def extract[T](fa: F[T]): T
+
+    def isFailure[T](fa: F[T]): Boolean
+
+    def assertImmediateChild(f: (String, NodeSeq) => F[NodeSeq]): Unit = {
+      val elem: Elem = <foo><bar value="1"/></foo>
+      assert(extract(f("bar", elem)) |==| <bar value="1"/>)
+      assert(isFailure(f("rar", elem)))
+    }
+
+    def assertChildren(f: (String, NodeSeq) => F[NodeSeq]): Unit = {
+      val elem: Elem = <foo><test><bar value="1"/></test></foo>
+      assert(extract(f("bar", elem)) |==| <bar value="1"/>)
+      assert(isFailure(f("rar", elem)))
+    }
+
+    def assertAttribute(f: (String, NodeSeq) => F[String]): Unit = {
+      val elem: Elem = <foo value="1"></foo>
+      assert(extract(f("value", elem)) == "1")
+      assert(isFailure(f("rar", elem)))
+    }
+
+    def assertText(f: NodeSeq => F[String]): Unit = {
+      val elem: Elem = <foo>TEST</foo>
+      assert(extract(f(elem)) == "TEST")
+      assert(isFailure(f(<rar/>)))
+    }
+
+    def assertTrimmedText(f: NodeSeq => F[String]): Unit = {
+      val elem: Elem = <foo> TEST </foo>
+      assert(extract(f(elem)) == "TEST")
+      assert(isFailure(f(<rar/>)))
+    }
+  }
+
+  object mandatory extends TypedXmlTraverseAsserts[Try] {
+    override def extract[T](fa: Try[T]): T = fa.get
+    override def isFailure[T](fa: Try[T]): Boolean = fa.isFailure
+  }
+  object optional extends TypedXmlTraverseAsserts[Option] {
+    override def extract[T](fa: Option[T]): T = fa.get
+    override def isFailure[T](fa: Option[T]): Boolean = fa.isEmpty
+  }
+}

--- a/src/test/scala/advxml/core/convert/ValidatedConverterTest.scala
+++ b/src/test/scala/advxml/core/convert/ValidatedConverterTest.scala
@@ -1,6 +1,6 @@
 package advxml.core.convert
 
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 import cats.data.Validated.Valid
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -17,7 +17,7 @@ class ValidatedConverterTest extends AnyFunSuite {
   test("Test ValidatedConverter.id") {
     val testValue = "TEST"
     val converter: ValidatedConverter[String, String] = ValidatedConverter.id
-    val value: ValidatedEx[String] = converter.run(testValue)
+    val value: ValidatedNelEx[String] = converter.run(testValue)
 
     assert(value == Valid(testValue))
   }

--- a/src/test/scala/advxml/core/convert/xml/XmlConverterTest.scala
+++ b/src/test/scala/advxml/core/convert/xml/XmlConverterTest.scala
@@ -18,7 +18,6 @@ class XmlConverterTest extends AnyFunSuite {
     val xml = <Person Name="Mario" Surname="Bianchi"/>
     val model = XmlConverter.asModel[Elem, Person](xml)
 
-    assert(model.isValid)
     assert(model.map(_.name) == Valid("Mario"))
     assert(model.map(_.surname) == Valid("Bianchi"))
   }

--- a/src/test/scala/advxml/core/transform/actions/XmlZoomTest.scala
+++ b/src/test/scala/advxml/core/transform/actions/XmlZoomTest.scala
@@ -12,13 +12,13 @@ class XmlZoomTest extends AnyFunSuite {
   import cats.instances.option._
 
   test("Test immediateDown") {
-    val xmlZoom = root immediateDown ("TEST")
-    assert(xmlZoom.zoomActions == List(ImmediateDown("TEST")))
+    val xmlZoom = root immediateDown "N1"
+    assert(xmlZoom.zoomActions == List(ImmediateDown("N1")))
   }
 
   test("Test andThen") {
-    val xmlZoom1 = root immediateDown ("N1")
-    val xmlZoom2 = > immediateDown ("N1")
+    val xmlZoom1 = root immediateDown "N1"
+    val xmlZoom2 = > immediateDown "N2"
     val result = xmlZoom1.andThen(xmlZoom2)
 
     assert(result.zoomActions.size == 2)

--- a/src/test/scala/advxml/core/validate/MonadExUtilsTest.scala
+++ b/src/test/scala/advxml/core/validate/MonadExUtilsTest.scala
@@ -14,7 +14,7 @@ class MonadExUtilsTest extends AnyFunSuite {
 
   test("Test get implicit MonadNelEx instance using apply method") {
     import advxml.instances.validate._
-    val monadNelExInstance = MonadNelEx[ValidatedEx]
+    val monadNelExInstance = MonadNelEx[ValidatedNelEx]
     assert(monadNelExInstance != null)
   }
 }

--- a/src/test/scala/advxml/core/validate/ValidateExTest.scala
+++ b/src/test/scala/advxml/core/validate/ValidateExTest.scala
@@ -11,78 +11,78 @@ class ValidateExTest extends AnyFunSuite with ValidatedExAsserts {
   //Transform
   test("Test ValidatedEx.transformE[Try] - Valid") {
     import cats.instances.try_._
-    assert_ValidatedEx_to_Try_Valid(ValidatedEx.transformE[Try, String](_))
+    assert_ValidatedEx_to_Try_Valid(ValidatedNelEx.transformE[Try, String](_))
   }
 
   test("Test ValidatedEx.transformE[Try] - Invalid") {
     import cats.instances.try_._
-    assert_ValidatedEx_to_Try_Invalid(ValidatedEx.transformE[Try, String](_))
+    assert_ValidatedEx_to_Try_Invalid(ValidatedNelEx.transformE[Try, String](_))
   }
 
   test("Test ValidatedEx.transformE[EitherEx] - Valid") {
     import cats.instances.either._
-    assert_ValidatedEx_to_EitherEx_Valid(ValidatedEx.transformE[EitherEx, String](_))
+    assert_ValidatedEx_to_EitherEx_Valid(ValidatedNelEx.transformE[EitherEx, String](_))
   }
 
   test("Test ValidatedEx.transformE[EitherEx] - Invalid") {
     import cats.instances.either._
-    assert_ValidatedEx_to_EitherEx_Invalid(ValidatedEx.transformE[EitherEx, String](_))
+    assert_ValidatedEx_to_EitherEx_Invalid(ValidatedNelEx.transformE[EitherEx, String](_))
   }
 
   test("Test ValidatedEx.transformE[EitherNelEx] - Valid") {
     import cats.instances.either._
-    assert_ValidatedEx_to_EitherNelEx_Valid(ValidatedEx.transformNE[EitherNelEx, String](_))
+    assert_ValidatedEx_to_EitherNelEx_Valid(ValidatedNelEx.transformNE[EitherNelEx, String](_))
   }
 
   test("Test ValidatedEx.transformE[EitherNelEx] - Invalid") {
     import cats.instances.either._
-    assert_ValidatedEx_to_EitherNelEx_Invalid(ValidatedEx.transformNE[EitherNelEx, String](_))
+    assert_ValidatedEx_to_EitherNelEx_Invalid(ValidatedNelEx.transformNE[EitherNelEx, String](_))
   }
 
   test("Test ValidatedEx.transformA[Option] - Valid") {
     import cats.instances.option._
-    assert_ValidatedEx_to_Option_Valid(ValidatedEx.transformA[Option, String](_))
+    assert_ValidatedEx_to_Option_Valid(ValidatedNelEx.transformA[Option, String](_))
   }
 
   test("Test ValidatedEx.transformA[Option] - Invalid") {
     import cats.instances.option._
-    assert_ValidatedEx_to_Option_Invalid(ValidatedEx.transformA[Option, String](_))
+    assert_ValidatedEx_to_Option_Invalid(ValidatedNelEx.transformA[Option, String](_))
   }
 
   //Converters
   //Try
   test("Test fromTry - Success") {
-    assert_Try_Success(ValidatedEx.fromTry)
+    assert_Try_Success(ValidatedNelEx.fromTry)
   }
 
   test("Test fromTry - Failure") {
-    assert_Try_Failure(ValidatedEx.fromTry)
+    assert_Try_Failure(ValidatedNelEx.fromTry)
   }
 
   //Either
   test("Test fromEither - Right") {
-    assert_EitherEx_Right(ValidatedEx.fromEither)
+    assert_EitherEx_Right(ValidatedNelEx.fromEither)
   }
 
   test("Test fromEither - Left") {
-    assert_EitherEx_Left(ValidatedEx.fromEither)
+    assert_EitherEx_Left(ValidatedNelEx.fromEither)
   }
 
   test("Test fromEitherNel - Right") {
-    assert_EitherNelEx_Right(ValidatedEx.fromEitherNel)
+    assert_EitherNelEx_Right(ValidatedNelEx.fromEitherNel)
   }
 
   test("Test fromEitherNel - Left") {
-    assert_EitherNelEx_Left(ValidatedEx.fromEitherNel)
+    assert_EitherNelEx_Left(ValidatedNelEx.fromEitherNel)
   }
 
   //Option
   test("Test fromOption - Some") {
-    assert_Option_Some((optionValue, ex) => ValidatedEx.fromOption(optionValue, ex))
+    assert_Option_Some((optionValue, ex) => ValidatedNelEx.fromOption(optionValue, ex))
   }
 
   test("Test fromOption - None") {
-    assert_Option_None((optionValue, ex) => ValidatedEx.fromOption(optionValue, ex))
+    assert_Option_None((optionValue, ex) => ValidatedNelEx.fromOption(optionValue, ex))
   }
 }
 
@@ -95,69 +95,69 @@ private[advxml] trait ValidatedExAsserts {
     new RuntimeException("TEXT_EX_2")
   )
 
-  def assert_ValidatedEx_to_Try_Valid(f: ValidatedEx[String] => Try[String]): Unit = {
+  def assert_ValidatedEx_to_Try_Valid(f: ValidatedNelEx[String] => Try[String]): Unit = {
     val value = "TEST"
-    val validatedExValue: ValidatedEx[String] = Validated.Valid(value)
+    val validatedExValue: ValidatedNelEx[String] = Validated.Valid(value)
     val result: Try[String] = f(validatedExValue)
 
     assert(result == Success(value))
   }
 
-  def assert_ValidatedEx_to_Try_Invalid(f: ValidatedEx[String] => Try[String]): Unit = {
+  def assert_ValidatedEx_to_Try_Invalid(f: ValidatedNelEx[String] => Try[String]): Unit = {
 
-    val validatedExValue: ValidatedEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
+    val validatedExValue: ValidatedNelEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
     val result = f(validatedExValue)
 
     assert(result.isFailure)
   }
 
-  def assert_ValidatedEx_to_EitherEx_Valid(f: ValidatedEx[String] => EitherEx[String]): Unit = {
+  def assert_ValidatedEx_to_EitherEx_Valid(f: ValidatedNelEx[String] => EitherEx[String]): Unit = {
     val value = "TEST"
-    val validatedExValue: ValidatedEx[String] = Validated.Valid(value)
+    val validatedExValue: ValidatedNelEx[String] = Validated.Valid(value)
     val result: EitherEx[String] = f(validatedExValue)
 
     assert(result == Right(value))
   }
 
-  def assert_ValidatedEx_to_EitherEx_Invalid(f: ValidatedEx[String] => EitherEx[String]): Unit = {
-    val validatedExValue: ValidatedEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
+  def assert_ValidatedEx_to_EitherEx_Invalid(f: ValidatedNelEx[String] => EitherEx[String]): Unit = {
+    val validatedExValue: ValidatedNelEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
     val result: EitherEx[String] = f(validatedExValue)
 
     assert(result.isLeft)
   }
 
-  def assert_ValidatedEx_to_EitherNelEx_Valid(f: ValidatedEx[String] => EitherNelEx[String]): Unit = {
+  def assert_ValidatedEx_to_EitherNelEx_Valid(f: ValidatedNelEx[String] => EitherNelEx[String]): Unit = {
     val value = "TEST"
-    val validatedExValue: ValidatedEx[String] = Validated.Valid(value)
+    val validatedExValue: ValidatedNelEx[String] = Validated.Valid(value)
     val result: EitherNelEx[String] = f(validatedExValue)
 
     assert(result == Right(value))
   }
 
-  def assert_ValidatedEx_to_EitherNelEx_Invalid(f: ValidatedEx[String] => EitherNelEx[String]): Unit = {
-    val validatedExValue: ValidatedEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
+  def assert_ValidatedEx_to_EitherNelEx_Invalid(f: ValidatedNelEx[String] => EitherNelEx[String]): Unit = {
+    val validatedExValue: ValidatedNelEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
 
     val result: EitherNelEx[String] = f(validatedExValue)
 
     assert(result.isLeft)
   }
 
-  def assert_ValidatedEx_to_Option_Valid(f: ValidatedEx[String] => Option[String]): Unit = {
+  def assert_ValidatedEx_to_Option_Valid(f: ValidatedNelEx[String] => Option[String]): Unit = {
     val value = "TEST"
-    val validatedExValue: ValidatedEx[String] = Validated.Valid(value)
+    val validatedExValue: ValidatedNelEx[String] = Validated.Valid(value)
     val result: Option[String] = f(validatedExValue)
 
     assert(result.contains(value))
   }
 
-  def assert_ValidatedEx_to_Option_Invalid(f: ValidatedEx[String] => Option[String]): Unit = {
-    val validatedExValue: ValidatedEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
+  def assert_ValidatedEx_to_Option_Invalid(f: ValidatedNelEx[String] => Option[String]): Unit = {
+    val validatedExValue: ValidatedNelEx[String] = Validated.Invalid(TEST_EXCEPTION_NEL)
     val result: Option[String] = f(validatedExValue)
 
     assert(result.isEmpty)
   }
 
-  def assert_Try_Success(f: Try[String] => ValidatedEx[String]): Unit = {
+  def assert_Try_Success(f: Try[String] => ValidatedNelEx[String]): Unit = {
     val value = "TEST"
     val tryValue: Try[String] = Success(value)
     val validatedExValue = f(tryValue)
@@ -165,14 +165,14 @@ private[advxml] trait ValidatedExAsserts {
     assertValid(validatedExValue, value)
   }
 
-  def assert_Try_Failure(f: Try[String] => ValidatedEx[String]): Unit = {
+  def assert_Try_Failure(f: Try[String] => ValidatedNelEx[String]): Unit = {
     val tryValue: Try[String] = Failure(TEST_EXCEPTION)
     val validatedExValue = f(tryValue)
 
     assertInvalid(validatedExValue)
   }
 
-  def assert_EitherEx_Right(f: EitherEx[String] => ValidatedEx[String]): Unit = {
+  def assert_EitherEx_Right(f: EitherEx[String] => ValidatedNelEx[String]): Unit = {
     val value = "TEST"
     val eitherValue: EitherEx[String] = Right(value)
     val validatedExValue = f(eitherValue)
@@ -180,16 +180,16 @@ private[advxml] trait ValidatedExAsserts {
     assertValid(validatedExValue, value)
   }
 
-  def assert_EitherEx_Left(f: EitherEx[String] => ValidatedEx[String]): Unit = {
+  def assert_EitherEx_Left(f: EitherEx[String] => ValidatedNelEx[String]): Unit = {
     val eitherValue: EitherEx[String] = Left(TEST_EXCEPTION)
     val validatedExValue = f(eitherValue)
 
     assertInvalid(validatedExValue)
   }
 
-  private def assertInvalid(v: ValidatedEx[_]): Unit = assert(v.isInvalid)
+  private def assertInvalid(v: ValidatedNelEx[_]): Unit = assert(v.isInvalid)
 
-  def assert_EitherNelEx_Right(f: EitherNelEx[String] => ValidatedEx[String]): Unit = {
+  def assert_EitherNelEx_Right(f: EitherNelEx[String] => ValidatedNelEx[String]): Unit = {
     val value = "TEST"
     val eitherValue: EitherNelEx[String] = Right(value)
     val validatedExValue = f(eitherValue)
@@ -197,7 +197,7 @@ private[advxml] trait ValidatedExAsserts {
     assertValid(validatedExValue, value)
   }
 
-  def assert_EitherNelEx_Left(f: EitherNelEx[String] => ValidatedEx[String]): Unit = {
+  def assert_EitherNelEx_Left(f: EitherNelEx[String] => ValidatedNelEx[String]): Unit = {
 
     val eitherValue: EitherNelEx[String] = Left(TEST_EXCEPTION_NEL)
     val validatedExValue = f(eitherValue)
@@ -205,7 +205,7 @@ private[advxml] trait ValidatedExAsserts {
     assertInvalid(validatedExValue)
   }
 
-  def assert_Option_Some(f: (Option[String], Throwable) => ValidatedEx[String]): Unit = {
+  def assert_Option_Some(f: (Option[String], Throwable) => ValidatedNelEx[String]): Unit = {
     val value = "TEST"
     val optionValue = Some(value)
     val validatedExValue = f(optionValue, TEST_EXCEPTION)
@@ -213,13 +213,13 @@ private[advxml] trait ValidatedExAsserts {
     assertValid(validatedExValue, value)
   }
 
-  private def assertValid[T](v: ValidatedEx[T], expectedValue: => T): Unit = {
+  private def assertValid[T](v: ValidatedNelEx[T], expectedValue: => T): Unit = {
     assert(v == Valid(expectedValue))
   }
 
-  def assert_Option_None(f: (Option[String], Throwable) => ValidatedEx[String]): Unit = {
+  def assert_Option_None(f: (Option[String], Throwable) => ValidatedNelEx[String]): Unit = {
     val optionValue: Option[String] = None
-    val validatedExValue: ValidatedEx[String] = f(optionValue, TEST_EXCEPTION)
+    val validatedExValue: ValidatedNelEx[String] = f(optionValue, TEST_EXCEPTION)
 
     assertInvalid(validatedExValue)
   }

--- a/src/test/scala/advxml/instances/ValidationInstanceTest.scala
+++ b/src/test/scala/advxml/instances/ValidationInstanceTest.scala
@@ -1,6 +1,6 @@
 package advxml.instances
 
-import advxml.core.validate.{ThrowableNel, ValidatedEx}
+import advxml.core.validate.{ThrowableNel, ValidatedNelEx}
 import advxml.core.validate.exceptions.AggregatedException
 import cats.Eq
 import cats.data.NonEmptyList
@@ -50,14 +50,14 @@ class ValidationInstanceTest extends AnyFunSuite with Discipline {
   checkAll(
     "MonadTests[ValidatedEx, Throwable]",
     cats.laws.discipline
-      .MonadErrorTests[ValidatedEx, Throwable]
+      .MonadErrorTests[ValidatedNelEx, Throwable]
       .monad[Int, Int, Int] //TODO: monadError
   )
 
   checkAll(
     "MonadTests[ValidatedEx, ThrowableNel]",
     cats.laws.discipline
-      .MonadErrorTests[ValidatedEx, ThrowableNel]
+      .MonadErrorTests[ValidatedNelEx, ThrowableNel]
       .monadError[Int, Int, Int]
   )
 }

--- a/src/test/scala/advxml/instances/ValidationInstanceTest.scala
+++ b/src/test/scala/advxml/instances/ValidationInstanceTest.scala
@@ -5,9 +5,10 @@ import advxml.core.validate.exceptions.AggregatedException
 import cats.Eq
 import cats.data.NonEmptyList
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatest.prop.Configuration
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
-class ValidationInstanceTest extends AnyFunSuite with Discipline {
+class ValidationInstanceTest extends AnyFunSuite with FunSuiteDiscipline with Configuration {
 
   import advxml.instances.validate._
   import cats.implicits._

--- a/src/test/scala/advxml/instances/XmlPredicateInstancesTest.scala
+++ b/src/test/scala/advxml/instances/XmlPredicateInstancesTest.scala
@@ -3,7 +3,7 @@ package advxml.instances
 import advxml.core.transform.actions.XmlPredicate.XmlPredicate
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.xml.{Document, Elem, Group}
+import scala.xml.{Document, Elem, Group, NodeSeq}
 
 class XmlPredicateInstancesTest extends AnyFunSuite {
 
@@ -74,5 +74,11 @@ class XmlPredicateInstancesTest extends AnyFunSuite {
     val target: Group = Group(<Node><SubNode>TEST</SubNode></Node>)
     val result: Boolean = p(target)
     assert(!result)
+  }
+
+  test("Test 'strictEqualsTo' predicate - with NodeSeq-NodeSeq") {
+    val ns1: NodeSeq = <Node><SubNode>TEST</SubNode></Node>.asInstanceOf[NodeSeq]
+    val ns2: NodeSeq = <Node><SubNode>TEST</SubNode></Node>.asInstanceOf[NodeSeq]
+    assert(strictEqualsTo(ns1)(ns2))
   }
 }

--- a/src/test/scala/advxml/syntax/ConvertersSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/ConvertersSyntaxTest.scala
@@ -1,7 +1,7 @@
 package advxml.syntax
 
 import advxml.core.convert.{Converter, PureConverter, ValidatedConverter}
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 import cats.data.Validated.Valid
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -68,7 +68,7 @@ class ConvertersSyntaxTest extends AnyFunSuite {
       ValidatedConverter.of(str => Valid(str.toInt))
 
     val value: String = "1"
-    val result: ValidatedEx[Int] = value.as[Int]
+    val result: ValidatedNelEx[Int] = value.as[Int]
 
     assert(result.toOption.get == 1)
   }

--- a/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
@@ -2,7 +2,7 @@ package advxml.syntax
 
 import advxml.core.convert.ValidatedConverter
 import advxml.core.convert.xml.{ModelToXml, XmlToModel}
-import advxml.core.validate.ValidatedEx
+import advxml.core.validate.ValidatedNelEx
 import cats.data.Validated.Valid
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -14,12 +14,14 @@ import scala.xml.Elem
   *
   * @author geirolad
   */
+//TODO: Check duplication into advxml.core.convert.xml.XmlConverterTest
 class XmlConverterSyntaxTest extends AnyFunSuite {
 
+  import advxml.instances.validate._
   import advxml.syntax.convert._
-  import advxml.syntax.nestedMap._
   import advxml.syntax.traverse.validated._
-  import cats.implicits._
+  import cats.instances.option._
+  import cats.syntax.all._
 
   test("XML to Model - Convert simple case class") {
 
@@ -29,12 +31,12 @@ class XmlConverterSyntaxTest extends AnyFunSuite {
       (
         x \@! "Name",
         x \@! "Surname",
-        x \@? "Age" nestedMap (_.toInt)
+        x.\@?("Age").map(_.toInt).valid
       ).mapN(Person)
     })
 
     val xml = <Person Name="Matteo" Surname="Bianchi"/>
-    val res: ValidatedEx[Person] = xml.as[Person]
+    val res: ValidatedNelEx[Person] = xml.as[Person]
 
     assert(res.map(_.name) == Valid("Matteo"))
     assert(res.map(_.surname) == Valid("Bianchi"))
@@ -52,7 +54,7 @@ class XmlConverterSyntaxTest extends AnyFunSuite {
     )
 
     val p = Person("Matteo", "Bianchi", Some(23))
-    val res: ValidatedEx[Elem] = p.as[Elem]
+    val res: ValidatedNelEx[Elem] = p.as[Elem]
 
     assert(res == Valid(<Person Name="Matteo" Surname="Bianchi" Age="23"/>))
   }

--- a/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlConverterSyntaxTest.scala
@@ -46,11 +46,10 @@ class XmlConverterSyntaxTest extends AnyFunSuite {
 
     case class Person(name: String, surname: String, age: Option[Int])
 
-    implicit val converter: ModelToXml[Person, Elem] = ValidatedConverter.of(
-      x =>
-        Valid(
-          <Person Name={x.name} Surname={x.surname} Age={x.age.map(_.toString).getOrElse("")}/>
-        )
+    implicit val converter: ModelToXml[Person, Elem] = ValidatedConverter.of(x =>
+      Valid(
+        <Person Name={x.name} Surname={x.surname} Age={x.age.map(_.toString).getOrElse("")}/>
+      )
     )
 
     val p = Person("Matteo", "Bianchi", Some(23))

--- a/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
@@ -26,7 +26,7 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec with XmlTraverserContractAss
       mandatory.assertText(_.![Try])
     }
     Scenario("|!|") {
-      mandatory.assertText(_.|!|[Try])
+      mandatory.assertTrimmedText(_.|!|[Try])
     }
   }
 
@@ -49,7 +49,7 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec with XmlTraverserContractAss
       optional.assertText(_.?[Option])
     }
     Scenario("|?|") {
-      optional.assertText(_.|?|[Option])
+      optional.assertTrimmedText(_.|?|[Option])
     }
   }
 
@@ -72,11 +72,11 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec with XmlTraverserContractAss
       mandatory.assertText(_.!)
     }
     Scenario("|!|") {
-      mandatory.assertText(_.|!|)
+      mandatory.assertTrimmedText(_.|!|)
     }
   }
 
-  Feature("XmlTraverserOptionalFloatOpsForId") {
+  Feature("XmlTraverserOptionalFixedOps") {
 
     import advxml.syntax.traverse.option._
     import cats.instances.option._
@@ -95,7 +95,7 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec with XmlTraverserContractAss
       optional.assertText(_.?)
     }
     Scenario("|?|") {
-      optional.assertText(_.|?|)
+      optional.assertTrimmedText(_.|?|)
     }
   }
 }

--- a/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
@@ -15,6 +15,8 @@ import scala.xml.NodeSeq
 class XmlTraverserSyntaxTest extends AnyFeatureSpec {
 
   import advxml.syntax.traverse.try_._
+  import cats.instances.option._
+  import cats.instances.try_._
 
   Feature("XmlTraverseSyntaxTest: Read Attributes") {
     Scenario("Read optional attribute") {
@@ -23,11 +25,11 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           <Employee Name="David"/>
         </Employers>
 
-      val name: Try[Option[String]] = xml \ "Employee" \@? "Name"
-      val age: Try[Option[String]] = xml \ "Employee" \@? "Age"
+      val name: Option[String] = xml \ "Employee" \@? "Name"
+      val age: Option[String] = xml \ "Employee" \@? "Age"
 
-      assert(name == Success(Some("David")))
-      assert(age == Success(None))
+      assert(name == Some("David"))
+      assert(age.isEmpty)
     }
 
     Scenario("Read required attribute") {
@@ -55,11 +57,11 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val cars: Try[Option[NodeSeq]] = xml \ "Employee" \? "Cars"
-      val works: Try[Option[NodeSeq]] = xml \ "Employee" \? "Works"
+      val cars: Option[NodeSeq] = xml \ "Employee" \? "Cars"
+      val works: Option[NodeSeq] = xml \ "Employee" \? "Works"
 
-      assert(cars.map(_.map(_.length)) == Success(Some(1)))
-      assert(works == Success(None))
+      assert(cars.map(_.length) == Some(1))
+      assert(works.isEmpty)
     }
 
     Scenario("Read optional immediate nodes waterfall") {
@@ -72,13 +74,13 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val cars: Try[Option[NodeSeq]] = xml \? "Employee" \? "Cars"
-      val works: Try[Option[NodeSeq]] = xml \? "Employee" \? "Works"
-      val data: Try[Option[NodeSeq]] = xml \? "Other" \? "Data"
+      val cars: Option[NodeSeq] = xml \? "Employee" \? "Cars"
+      val works: Option[NodeSeq] = xml \? "Employee" \? "Works"
+      val data: Option[NodeSeq] = xml \? "Other" \? "Data"
 
-      assert(cars.map(_.map(_.length)) == Success(Some(1)))
-      assert(works == Success(None))
-      assert(data == Success(None))
+      assert(cars.map(_.length) == Some(1))
+      assert(works.isEmpty)
+      assert(data.isEmpty)
     }
 
     Scenario("Read required immediate nodes") {
@@ -129,12 +131,11 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val cars: Try[Option[NodeSeq]] = xml \\? "Cars"
-      val works: Try[Option[NodeSeq]] = xml \\? "Works"
+      val cars: Option[NodeSeq] = xml \\? "Cars"
+      val works: Option[NodeSeq] = xml \\? "Works"
 
-      assert(cars.get.isDefined)
-      assert(cars.map(_.map(_.length)) == Success(Some(1)))
-      assert(works == Success(None))
+      assert(cars.map(_.length) == Some(1))
+      assert(works.isEmpty)
     }
 
     Scenario("Read required nested nodes") {
@@ -167,11 +168,11 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val note: Try[Option[String]] = xml \ "Employee" \ "Note" ?
-      val works: Try[Option[String]] = xml \ "Employee" \ "Works" ?
+      val note: Option[String] = xml \ "Employee" \ "Note" |?|
+      val works: Option[String] = xml \ "Employee" \ "Works" |?|
 
-      assert(note.map(_.map(_.trim)) == Success(Some(noteData)))
-      assert(works == Success(None))
+      assert(note === Some(noteData))
+      assert(works.isEmpty)
     }
 
     Scenario("Read optional text waterfall") {
@@ -185,11 +186,11 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val note: Try[Option[String]] = xml \? "Employee" \? "Note" ?
-      val works: Try[Option[String]] = xml \? "Employee" \? "Works" ?
+      val note: Option[String] = xml \? "Employee" \? "Note" |?|
+      val works: Option[String] = xml \? "Employee" \? "Works" |?|
 
-      assert(note.map(_.map(_.trim)) == Success(Some(noteData)))
-      assert(works == Success(None))
+      assert(note === Some(noteData))
+      assert(works.isEmpty)
     }
 
     Scenario("Read required text") {
@@ -203,8 +204,8 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val note: Try[String] = xml \ "Employee" \ "Note" !
-      val works: Try[String] = xml \ "Employee" \ "Works" !
+      val note: Try[String] = xml \ "Employee" \ "Note" |!|
+      val works: Try[String] = xml \ "Employee" \ "Works" |!|
 
       assert(note.map(_.trim) == Success(noteData))
       assert(works.isFailure)
@@ -221,8 +222,8 @@ class XmlTraverserSyntaxTest extends AnyFeatureSpec {
           </Employee>
         </Employers>
 
-      val note: Try[String] = xml \ "Employee" \ "Note" !
-      val works: Try[String] = xml \! "Employee" \! "Works" !
+      val note: Try[String] = xml \ "Employee" \ "Note" |!|
+      val works: Try[String] = xml \! "Employee" \! "Works" |!|
 
       assert(note.map(_.trim) == Success(noteData))
       assert(works.isFailure)

--- a/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
+++ b/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest.scala
@@ -1,232 +1,101 @@
 package advxml.syntax
 
+import advxml.core.XmlTraverserContractAsserts
 import org.scalatest.featurespec.AnyFeatureSpec
 
-import scala.language.postfixOps
-import scala.util.{Success, Try}
-import scala.xml.NodeSeq
+import scala.util.Try
 
-/**
-  * Advxml
-  * Created by geirolad on 19/06/2019.
-  *
-  * @author geirolad
-  */
-class XmlTraverserSyntaxTest extends AnyFeatureSpec {
+class XmlTraverserSyntaxTest extends AnyFeatureSpec with XmlTraverserContractAsserts {
 
-  import advxml.syntax.traverse.try_._
-  import cats.instances.option._
-  import cats.instances.try_._
+  Feature("XmlTraverserMandatoryFloatOpsForId") {
 
-  Feature("XmlTraverseSyntaxTest: Read Attributes") {
-    Scenario("Read optional attribute") {
-      val xml =
-        <Employers>
-          <Employee Name="David"/>
-        </Employers>
+    import advxml.syntax.traverse._
+    import cats.instances.try_._
 
-      val name: Option[String] = xml \ "Employee" \@? "Name"
-      val age: Option[String] = xml \ "Employee" \@? "Age"
-
-      assert(name == Some("David"))
-      assert(age.isEmpty)
+    Scenario("\\!") {
+      mandatory.assertImmediateChild((nodeName, doc) => doc.\![Try](nodeName))
     }
 
-    Scenario("Read required attribute") {
-      val xml =
-        <Employers>
-          <Employee Name="David"/>
-        </Employers>
-
-      val name: Try[String] = xml \ "Employee" \@! "Name"
-      val age: Try[String] = xml \ "Employee" \@! "Age"
-
-      assert(name == Success("David"))
-      assert(age.isFailure)
+    Scenario("\\\\!") {
+      mandatory.assertChildren((nodeName, doc) => doc.\\![Try](nodeName))
+    }
+    Scenario("\\@!") {
+      mandatory.assertAttribute((attrName, doc) => doc.\@![Try](attrName))
+    }
+    Scenario("!") {
+      mandatory.assertText(_.![Try])
+    }
+    Scenario("|!|") {
+      mandatory.assertText(_.|!|[Try])
     }
   }
 
-  Feature("XmlTraverseSyntaxTest: Read Immediate Nodes") {
-    Scenario("Read optional immediate nodes") {
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Cars>
-              <Car Model="Fiat"/>
-            </Cars>
-          </Employee>
-        </Employers>
+  Feature("XmlTraverserOptionalFloatOpsForId") {
 
-      val cars: Option[NodeSeq] = xml \ "Employee" \? "Cars"
-      val works: Option[NodeSeq] = xml \ "Employee" \? "Works"
+    import advxml.syntax.traverse._
+    import cats.instances.option._
 
-      assert(cars.map(_.length) == Some(1))
-      assert(works.isEmpty)
+    Scenario("\\?") {
+      optional.assertImmediateChild((nodeName, doc) => doc.\?[Option](nodeName))
     }
 
-    Scenario("Read optional immediate nodes waterfall") {
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Cars>
-              <Car Model="Fiat"/>
-            </Cars>
-          </Employee>
-        </Employers>
-
-      val cars: Option[NodeSeq] = xml \? "Employee" \? "Cars"
-      val works: Option[NodeSeq] = xml \? "Employee" \? "Works"
-      val data: Option[NodeSeq] = xml \? "Other" \? "Data"
-
-      assert(cars.map(_.length) == Some(1))
-      assert(works.isEmpty)
-      assert(data.isEmpty)
+    Scenario("\\\\?") {
+      optional.assertChildren((nodeName, doc) => doc.\\?[Option](nodeName))
     }
-
-    Scenario("Read required immediate nodes") {
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Cars>
-              <Car Model="Fiat"/>
-            </Cars>
-          </Employee>
-        </Employers>
-
-      val cars: Try[NodeSeq] = xml \ "Employee" \! "Cars"
-      val works: Try[NodeSeq] = xml \ "Employee" \! "Works"
-
-      assert(cars.map(_.length) == Success(1))
-      assert(works.isFailure)
+    Scenario("\\@?") {
+      optional.assertAttribute((attrName, doc) => doc.\@?[Option](attrName))
     }
-
-    Scenario("Read required immediate nodes waterfall") {
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Cars>
-              <Car Model="Fiat"/>
-            </Cars>
-          </Employee>
-        </Employers>
-
-      val cars: Try[NodeSeq] = xml \! "Employee" \! "Cars"
-      val works: Try[NodeSeq] = xml \! "Employee" \! "Works"
-      val data: Try[NodeSeq] = xml \! "Other" \! "Data"
-
-      assert(cars.map(_.length) == Success(1))
-      assert(works.isFailure)
-      assert(data.isFailure)
+    Scenario("?") {
+      optional.assertText(_.?[Option])
+    }
+    Scenario("|?|") {
+      optional.assertText(_.|?|[Option])
     }
   }
 
-  Feature("XmlTraverseSyntaxTest: Read nested Nodes") {
-    Scenario("Read optional nested nodes") {
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Cars>
-              <Car Model="Fiat"/>
-            </Cars>
-          </Employee>
-        </Employers>
+  Feature("XmlTraverserMandatoryFixedOps") {
 
-      val cars: Option[NodeSeq] = xml \\? "Cars"
-      val works: Option[NodeSeq] = xml \\? "Works"
+    import advxml.syntax.traverse.try_._
+    import cats.instances.try_._
 
-      assert(cars.map(_.length) == Some(1))
-      assert(works.isEmpty)
+    Scenario("\\!") {
+      mandatory.assertImmediateChild((nodeName, doc) => doc.\!(nodeName))
     }
 
-    Scenario("Read required nested nodes") {
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Cars>
-              <Car Model="Fiat"/>
-            </Cars>
-          </Employee>
-        </Employers>
-
-      val cars: Try[NodeSeq] = xml \\! "Cars"
-      val works: Try[NodeSeq] = xml \\! "Works"
-
-      assert(cars.map(_.length) == Success(1))
-      assert(works.isFailure)
+    Scenario("\\\\!") {
+      mandatory.assertChildren((nodeName, doc) => doc.\\!(nodeName))
+    }
+    Scenario("\\@!") {
+      mandatory.assertAttribute((attrName, doc) => doc.\@!(attrName))
+    }
+    Scenario("!") {
+      mandatory.assertText(_.!)
+    }
+    Scenario("|!|") {
+      mandatory.assertText(_.|!|)
     }
   }
 
-  Feature("XmlTraverseSyntaxTest: Read content") {
-    Scenario("Read optional text") {
-      val noteData = "This is a test"
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Note>
-              {noteData}
-            </Note>
-          </Employee>
-        </Employers>
+  Feature("XmlTraverserOptionalFloatOpsForId") {
 
-      val note: Option[String] = xml \ "Employee" \ "Note" |?|
-      val works: Option[String] = xml \ "Employee" \ "Works" |?|
+    import advxml.syntax.traverse.option._
+    import cats.instances.option._
 
-      assert(note === Some(noteData))
-      assert(works.isEmpty)
+    Scenario("\\?") {
+      optional.assertImmediateChild((nodeName, doc) => doc.\?(nodeName))
     }
 
-    Scenario("Read optional text waterfall") {
-      val noteData = "This is a test"
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Note>
-              {noteData}
-            </Note>
-          </Employee>
-        </Employers>
-
-      val note: Option[String] = xml \? "Employee" \? "Note" |?|
-      val works: Option[String] = xml \? "Employee" \? "Works" |?|
-
-      assert(note === Some(noteData))
-      assert(works.isEmpty)
+    Scenario("\\\\?") {
+      optional.assertChildren((nodeName, doc) => doc.\\?(nodeName))
     }
-
-    Scenario("Read required text") {
-      val noteData = "This is a test"
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Note>
-              {noteData}
-            </Note>
-          </Employee>
-        </Employers>
-
-      val note: Try[String] = xml \ "Employee" \ "Note" |!|
-      val works: Try[String] = xml \ "Employee" \ "Works" |!|
-
-      assert(note.map(_.trim) == Success(noteData))
-      assert(works.isFailure)
+    Scenario("\\@?") {
+      optional.assertAttribute((attrName, doc) => doc.\@?(attrName))
     }
-
-    Scenario("Read required text waterfall") {
-      val noteData = "This is a test"
-      val xml =
-        <Employers>
-          <Employee Name="David">
-            <Note>
-              {noteData}
-            </Note>
-          </Employee>
-        </Employers>
-
-      val note: Try[String] = xml \ "Employee" \ "Note" |!|
-      val works: Try[String] = xml \! "Employee" \! "Works" |!|
-
-      assert(note.map(_.trim) == Success(noteData))
-      assert(works.isFailure)
+    Scenario("?") {
+      optional.assertText(_.?)
+    }
+    Scenario("|?|") {
+      optional.assertText(_.|?|)
     }
   }
 }

--- a/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest_old.scala
+++ b/src/test/scala/advxml/syntax/XmlTraverserSyntaxTest_old.scala
@@ -1,0 +1,306 @@
+package advxml.syntax
+
+import org.scalatest.featurespec.AnyFeatureSpec
+
+import scala.language.postfixOps
+import scala.util.{Success, Try}
+import scala.xml.NodeSeq
+
+/**
+  * Advxml
+  * Created by geirolad on 19/06/2019.
+  *
+  * @author geirolad
+  */
+class XmlTraverserSyntaxTest_old extends AnyFeatureSpec {
+
+  import cats.instances.option._
+  import cats.instances.try_._
+  import advxml.syntax.traverse.try_._
+
+  Feature("XmlTraverseFixed: Read Attributes") {
+    Scenario("Read optional attribute") {
+      val xml =
+        <Employers>
+          <Employee Name="David"/>
+        </Employers>
+
+      val name: Option[String] = xml \ "Employee" \@? "Name"
+      val age: Option[String] = xml \ "Employee" \@? "Age"
+
+      assert(name == Some("David"))
+      assert(age.isEmpty)
+    }
+
+    Scenario("Read required attribute") {
+      val xml =
+        <Employers>
+          <Employee Name="David"/>
+        </Employers>
+
+      val name: Try[String] = xml \ "Employee" \@! "Name"
+      val age: Try[String] = xml \ "Employee" \@! "Age"
+
+      assert(name == Success("David"))
+      assert(age.isFailure)
+    }
+  }
+
+  Feature("XmlTraverseFixed: Read Immediate Nodes") {
+    Scenario("Read optional immediate nodes") {
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Cars>
+              <Car Model="Fiat"/>
+            </Cars>
+          </Employee>
+        </Employers>
+
+      val cars: Option[NodeSeq] = xml \ "Employee" \? "Cars"
+      val works: Option[NodeSeq] = xml \ "Employee" \? "Works"
+
+      assert(cars.map(_.length) == Some(1))
+      assert(works.isEmpty)
+    }
+
+    Scenario("Read optional immediate nodes waterfall") {
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Cars>
+              <Car Model="Fiat"/>
+            </Cars>
+          </Employee>
+        </Employers>
+
+      val cars: Option[NodeSeq] = xml \? "Employee" \? "Cars"
+      val works: Option[NodeSeq] = xml \? "Employee" \? "Works"
+      val data: Option[NodeSeq] = xml \? "Other" \? "Data"
+
+      assert(cars.map(_.length) == Some(1))
+      assert(works.isEmpty)
+      assert(data.isEmpty)
+    }
+
+    Scenario("Read required immediate nodes") {
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Cars>
+              <Car Model="Fiat"/>
+            </Cars>
+          </Employee>
+        </Employers>
+
+      val cars: Try[NodeSeq] = xml \ "Employee" \! "Cars"
+      val works: Try[NodeSeq] = xml \ "Employee" \! "Works"
+
+      assert(cars.map(_.length) == Success(1))
+      assert(works.isFailure)
+    }
+
+    Scenario("Read required immediate nodes waterfall") {
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Cars>
+              <Car Model="Fiat"/>
+            </Cars>
+          </Employee>
+        </Employers>
+
+      val cars: Try[NodeSeq] = xml \! "Employee" \! "Cars"
+      val works: Try[NodeSeq] = xml \! "Employee" \! "Works"
+      val data: Try[NodeSeq] = xml \! "Other" \! "Data"
+
+      assert(cars.map(_.length) == Success(1))
+      assert(works.isFailure)
+      assert(data.isFailure)
+    }
+  }
+
+  Feature("XmlTraverseFixed: Read nested Nodes") {
+    Scenario("Read optional nested nodes") {
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Cars>
+              <Car Model="Fiat"/>
+            </Cars>
+          </Employee>
+        </Employers>
+
+      val cars: Option[NodeSeq] = xml \\? "Cars"
+      val works: Option[NodeSeq] = xml \\? "Works"
+
+      assert(cars.map(_.length) == Some(1))
+      assert(works.isEmpty)
+    }
+
+    Scenario("Read required nested nodes") {
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Cars>
+              <Car Model="Fiat"/>
+            </Cars>
+          </Employee>
+        </Employers>
+
+      val cars: Try[NodeSeq] = xml \\! "Cars"
+      val works: Try[NodeSeq] = xml \\! "Works"
+
+      assert(cars.map(_.length) == Success(1))
+      assert(works.isFailure)
+    }
+  }
+
+  Feature("XmlTraverseFixed: Read trimmed content") {
+    Scenario("Read optional text") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Option[String] = xml \ "Employee" \ "Note" |?|
+      val works: Option[String] = xml \ "Employee" \ "Works" |?|
+
+      assert(note === Some(noteData))
+      assert(works.isEmpty)
+    }
+
+    Scenario("Read optional text waterfall") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Option[String] = xml \? "Employee" \? "Note" |?|
+      val works: Option[String] = xml \? "Employee" \? "Works" |?|
+
+      assert(note === Some(noteData))
+      assert(works.isEmpty)
+    }
+
+    Scenario("Read required text") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Try[String] = xml \ "Employee" \ "Note" |!|
+      val works: Try[String] = xml \ "Employee" \ "Works" |!|
+
+      assert(note == Success(noteData))
+      assert(works.isFailure)
+    }
+
+    Scenario("Read required text waterfall") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Try[String] = xml \ "Employee" \ "Note" |!|
+      val works: Try[String] = xml \! "Employee" \! "Works" |!|
+
+      assert(note == Success(noteData))
+      assert(works.isFailure)
+    }
+  }
+
+  Feature("XmlTraverseFixed: Read content") {
+    Scenario("Read optional text") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Option[String] = xml \ "Employee" \ "Note" ?
+      val works: Option[String] = xml \ "Employee" \ "Works" ?
+
+      assert(note.map(_.trim) === Some(noteData))
+      assert(works.isEmpty)
+    }
+
+    Scenario("Read optional text waterfall") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Option[String] = xml \? "Employee" \? "Note" ?
+      val works: Option[String] = xml \? "Employee" \? "Works" ?
+
+      assert(note.map(_.trim) === Some(noteData))
+      assert(works.isEmpty)
+    }
+
+    Scenario("Read required text") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Try[String] = xml \ "Employee" \ "Note" !
+      val works: Try[String] = xml \ "Employee" \ "Works" !
+
+      assert(note.map(_.trim) == Success(noteData))
+      assert(works.isFailure)
+    }
+
+    Scenario("Read required text waterfall") {
+      val noteData = "This is a test"
+      val xml =
+        <Employers>
+          <Employee Name="David">
+            <Note>
+              {noteData}
+            </Note>
+          </Employee>
+        </Employers>
+
+      val note: Try[String] = xml \ "Employee" \ "Note" !
+      val works: Try[String] = xml \! "Employee" \! "Works" !
+
+      assert(note.map(_.trim) == Success(noteData))
+      assert(works.isFailure)
+    }
+  }
+}


### PR DESCRIPTION

## Changes
- _[Breaking changes]_ Refactoring `XmlTraverser`, the goals of these changes are simplify core and usability.
- `ValidatedEx` has been deprecated, `ValidatedNelEx` replace it.
- Update travis-ci badge to travis.com

## Updates
- scalafmt-core 2.4.2
- scalactic 3.1.1
- scalatest 3.1.1
- discipline-scalatest 1.0.1
