### PR TITLE
Add support for Scala 3

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,14 +22,18 @@ env:
 # jobs
 jobs:
   build:
-
+    name: build (${{ matrix.scala }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # supported scala versions
-        scala:
-          - 2.12.8
-          - 2.13.4
+        include:
+          - scala: 2.12.14
+            test-tasks: coverage test coverageReport
+          - scala: 2.13.6
+            test-tasks: coverage test coverageReport
+          - scala: 3.0.1
+            test-tasks: test # scoverage doesn’t support Scala 3
 
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +57,7 @@ jobs:
 
       #----------- COMPILE -----------
       - name: Compile, Format, Test and Coverage for ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean scalafmtCheck coverage test coverageReport
+        run: sbt ++${{ matrix.scala }} clean scalafmtCheck ${{ matrix.test-tasks }}
 
       #----------- COVERAGE -----------
       - name: Codecov

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,8 +4,9 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - check-success=codecov/patch
       - check-success=codecov/project
-      - check-success=build (2.12.8)
-      - check-success=build (2.13.4)
+      - check-success=build (2.12.14)
+      - check-success=build (2.13.6)
+      - check-success=build (3.0.1)
       - base=master
       - label!=work-in-progress
     actions:
@@ -17,8 +18,9 @@ pull_request_rules:
       - author=scala-steward
       - check-success=codecov/patch
       - check-success=codecov/project
-      - check-success=build (2.12.8)
-      - check-success=build (2.13.4)
+      - check-success=build (2.12.14)
+      - check-success=build (2.13.6)
+      - check-success=build (3.0.1)
       - base=master
     actions:
       merge:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,8 @@ version = 2.7.5
 style = defaultWithAlign
 encoding = "UTF-8"
 
+project.excludeFilters = [ "modules/core/src/main/scala-3" ]
+
 align.openParenCallSite = false
 align.openParenDefnSite = false
 align.tokens = [

--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ The idea behind this library is offer a fluent syntax to edit and read xml.
  ## Contributors
  - [@pawelkaczor](https://github.com/pawelkaczor)
  - [@dcsobral](https://github.com/dcsobral)
+ - [@liff](https://github.com/liff)

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val noPublishSettings = Seq(
 
 lazy val baseSettings = Seq(
   //scala options
-  crossScalaVersions := List("2.12.14", "2.13.6"),
+  crossScalaVersions := List("2.12.14", "2.13.6", "3.0.1"),
   scalaVersion       := crossScalaVersions.value.head,
   scalacOptions ++= scalacSettings(scalaVersion.value),
   Compile / console / scalacOptions --= Seq(
@@ -65,69 +65,92 @@ lazy val baseSettings = Seq(
   ),
   //dependencies
   resolvers ++= Resolvers.all,
-  libraryDependencies ++= Dependencies.common
+  libraryDependencies ++= Dependencies.common,
+  libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 12)) => Dependencies.extraDependenciesForScala2_12
+    case Some((2, 13)) => Dependencies.extraDependenciesForScala2_13
+    case Some((3, _))  => Dependencies.extraDependenciesForScala3
+    case _             => Nil
+  })
 )
 
 lazy val compilePlugins = Seq(
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
+  libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, _)) => Dependencies.Plugins.compilerPluginsFor2
+    case Some((3, _)) => Dependencies.Plugins.compilerPluginsFor3
+    case _            => Nil
+  })
 )
 
-def scalacSettings(scalaVersion: String): Seq[String] =
-  Seq(
-//    "-Xlog-implicits",
-    "-deprecation", // Emit warning and location for usages of deprecated APIs.
-    "-encoding",
-    "utf-8", // Specify character encoding used by source files.
-    "-explaintypes", // Explain type errors in more detail.
-    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
-    "-language:experimental.macros", // Allow macro definition (besides implementation and application)
-    "-language:higherKinds", // Allow higher-kinded types
-    "-language:implicitConversions", // Allow definition of implicit functions called views
-    "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
-    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
-    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit", // Option.apply used implicit view.
-    "-Xlint:package-object-classes", // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-    "-Ywarn-dead-code", // Warn when dead code is identified.
-    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
-    "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
-    "-Ywarn-numeric-widen", // Warn when numerics are widened.
-    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
-    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
-    "-Ywarn-unused:locals", // Warn if a local definition is unused.
-    "-Ywarn-unused:explicits", // Warn if a explicit value parameter is unused.
-    "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
-    "-Ywarn-unused:privates", // Warn if a private member is unused.
-    "-Ywarn-macros:after" //Tells the compiler to make the unused checks after macro expansion
-  ) ++ {
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, 12)) =>
-        Seq(
-          "-Ypartial-unification", // Enable partial unification in type constructor inference
-          "-Xlint:unsound-match", // Pattern match may not be typesafe.
-          "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-          "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-          "-Yno-adapted-args" // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-        )
-      case _ => Nil
-    }
+def scalacSettings(scalaVersion: String): Seq[String] = {
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, _)) =>
+      Seq(
+//        "-Xlog-implicits",
+        "-deprecation", // Emit warning and location for usages of deprecated APIs.
+        "-encoding",
+        "utf-8", // Specify character encoding used by source files.
+        "-explaintypes", // Explain type errors in more detail.
+        "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+        "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+        "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+        "-language:higherKinds", // Allow higher-kinded types
+        "-language:implicitConversions", // Allow definition of implicit functions called views
+        "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+        "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+        "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+        "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+        "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+        "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+        "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+        "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+        "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+        "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+        "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+        "-Xlint:option-implicit", // Option.apply used implicit view.
+        "-Xlint:package-object-classes", // Class or object defined in package object.
+        "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+        "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+        "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+        "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+        "-Ywarn-dead-code", // Warn when dead code is identified.
+        "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+        "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+        "-Ywarn-numeric-widen", // Warn when numerics are widened.
+        "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
+        "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+        "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+        "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+        "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+        "-Ywarn-unused:locals", // Warn if a local definition is unused.
+        "-Ywarn-unused:explicits", // Warn if a explicit value parameter is unused.
+        "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+        "-Ywarn-unused:privates", // Warn if a private member is unused.
+        "-Ywarn-macros:after" //Tells the compiler to make the unused checks after macro expansion
+      )
+    case _ =>
+      Seq(
+        "-deprecation",
+        "-explain-types",
+        "-feature",
+        "-unchecked",
+        "-Ykind-projector",
+        "-Xfatal-warnings"
+      )
   }
+} ++ {
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, 12)) =>
+      Seq(
+        "-Ypartial-unification", // Enable partial unification in type constructor inference
+        "-Xlint:unsound-match", // Pattern match may not be typesafe.
+        "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+        "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+        "-Yno-adapted-args" // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      )
+    case _ => Nil
+  }
+}
 
 //=============================== ALIASES ===============================
 addCommandAlias("check", ";clean;test")

--- a/modules/core/src/main/scala/advxml/core/TypeInequalities.scala
+++ b/modules/core/src/main/scala/advxml/core/TypeInequalities.scala
@@ -1,15 +1,14 @@
 package advxml.core
 
+import scala.annotation.implicitNotFound
+
 // $COVERAGE-OFF$
-sealed class =:!=[A, B]
+@implicitNotFound(msg = "Cannot prove that ${A} =:!= ${B}.")
+sealed trait =:!=[A, B]
 
-object =:!= extends LowerPriorityImplicits {
-  implicit def nequal[A, B](implicit same: A =:= B = null): =:!=[A, B] =
-    if (same != null) sys.error("should not be called explicitly with same type")
-    else new =:!=[A, B]
-}
-
-trait LowerPriorityImplicits {
-  implicit def equal[A]: =:!=[A, A] = sys.error("should not be called")
+object =:!= {
+  implicit def neq[A, B]: A =:!= B = new =:!=[A, B] {}
+  implicit def neqAmbig1[A]: A =:!= A = null
+  implicit def neqAmbig2[A]: A =:!= A = null
 }
 // $COVERAGE-ON$

--- a/modules/core/src/main/scala/advxml/core/data/Converter.scala
+++ b/modules/core/src/main/scala/advxml/core/data/Converter.scala
@@ -62,7 +62,6 @@ object Converter {
 
 //=================================== HELPERS ============================================
 private[core] sealed abstract class FixedBiConverterOps[F[_]: Applicative, C[-A, B] <: Converter[A, F[B]]] {
-  type Wrapper[_] = F[_]
   def of[A, B](f: A => F[B]): C[A, B] = Converter.of[A, F[B]](f).asInstanceOf[C[A, B]]
   def id[A]: C[A, A] = Converter.idF[F, A].asInstanceOf[C[A, A]]
   def const[A, B](b: B): C[A, B] = Converter.constF(b).asInstanceOf[C[A, B]]
@@ -70,7 +69,6 @@ private[core] sealed abstract class FixedBiConverterOps[F[_]: Applicative, C[-A,
 }
 
 private[core] sealed abstract class FixedLeftConverterOps[F[_]: Applicative, A, CR[B] <: Converter[A, F[B]]] {
-  type Wrapper[_] = F[_]
   def of[B](f: A => F[B]): CR[B] = Converter.of[A, F[B]](f).asInstanceOf[CR[B]]
   def id: CR[A] = Converter.idF[F, A].asInstanceOf[CR[A]]
   def const[B](b: B): CR[B] = Converter.constF[F, A, B](b).asInstanceOf[CR[B]]
@@ -78,7 +76,6 @@ private[core] sealed abstract class FixedLeftConverterOps[F[_]: Applicative, A, 
 }
 
 private[core] sealed abstract class FixedRightConverterOps[F[_]: Applicative, B, CL[A] <: Converter[A, F[B]]] {
-  type Wrapper[_] = F[_]
   def of[A](f: A => F[B]): CL[A] = Converter.of[A, F[B]](f).asInstanceOf[CL[A]]
   def id: CL[B] = Converter.idF[F, B].asInstanceOf[CL[B]]
   def const[A](b: B): CL[A] = Converter.constF[F, A, B](b).asInstanceOf[CL[A]]

--- a/modules/core/src/main/scala/advxml/core/data/Value.scala
+++ b/modules/core/src/main/scala/advxml/core/data/Value.scala
@@ -33,7 +33,7 @@ object Value {
   }
 }
 
-case class SimpleValue(private val data: String, ref: Option[String] = None)
+case class SimpleValue(private[data] val data: String, ref: Option[String] = None)
     extends Value
     with Comparable[SimpleValue] {
 
@@ -44,10 +44,14 @@ case class SimpleValue(private val data: String, ref: Option[String] = None)
 
   override def toString: String = Show[SimpleValue].show(this)
 }
-object SimpleValue {
-
+private[data] sealed trait SimpleValueLowPriorityInstances {
   implicit def valueExtractorForSimpleValueF[F[_]: Applicative]: ValueExtractor[F, SimpleValue] =
     (value: SimpleValue) => Applicative[F].pure(value.data)
+}
+object SimpleValue extends SimpleValueLowPriorityInstances {
+
+  implicit def valueExtractorForSimpleValueId: ValueExtractor[Id, SimpleValue] =
+    (value: SimpleValue) => value.data
 
   implicit val advxmlValueCatsInstances: PartialOrder[SimpleValue] with Show[SimpleValue] =
     new PartialOrder[SimpleValue] with Show[SimpleValue] {

--- a/modules/core/src/main/scala/advxml/core/transform/XmlZoom.scala
+++ b/modules/core/src/main/scala/advxml/core/transform/XmlZoom.scala
@@ -230,12 +230,12 @@ object XmlZoom {
     val symbol: String = s"($idx)"
   }
 
-  final case object Head extends FilterZoomAction {
+  case object Head extends FilterZoomAction {
     def apply(ns: NodeSeq): Option[NodeSeq] = ns.headOption
     val symbol: String = s"head()"
   }
 
-  final case object Last extends FilterZoomAction {
+  case object Last extends FilterZoomAction {
     def apply(ns: NodeSeq): Option[NodeSeq] = ns.lastOption
     val symbol: String = s"last()"
   }

--- a/modules/core/src/main/scala/advxml/core/utils/XmlUtils.scala
+++ b/modules/core/src/main/scala/advxml/core/utils/XmlUtils.scala
@@ -14,10 +14,7 @@ object XmlUtils {
     Elem(null, n.label, n.attributes, n.scope, false, n.child: _*)
 
   def flatMapChildren(e: Elem, f: Node => NodeSeq): Elem = {
-    val updatedChildren: Seq[Node] = e.child.filterNot(emptyText).flatMap {
-      case n: Node => f(n)
-      case o       => o
-    }
+    val updatedChildren: Seq[Node] = e.child.filterNot(emptyText).flatMap(f)
 
     e.copy(child = updatedChildren)
   }

--- a/modules/core/src/main/scala/advxml/instances/AllTransforInstances.scala
+++ b/modules/core/src/main/scala/advxml/instances/AllTransforInstances.scala
@@ -225,7 +225,7 @@ private[instances] trait XmlPredicateInstances {
   def attrs(values: NonEmptyList[KeyValuePredicate]): XmlPredicate =
     values
       .map(p => XmlPredicate(ns => p(SimpleValue(ns \@ p.key.value))))
-      .reduce(Predicate.and[NodeSeq])
+      .reduce(Predicate.and[NodeSeq](_, _))
 
   /** Create a [[advxml.core.data.XmlPredicate]] that can check if a NodeSeq contains a child with specified predicates
     *

--- a/modules/core/src/main/scala/advxml/syntax/AllTransformSyntax.scala
+++ b/modules/core/src/main/scala/advxml/syntax/AllTransformSyntax.scala
@@ -60,11 +60,11 @@ private[syntax] sealed trait RuleSyntax {
 
 private[syntax] sealed trait ZoomSyntax {
 
-  implicit class XmlZoomNodeBaseOps[Z <: XmlZoomNodeBase](zoom: Z) {
+  implicit class XmlZoomNodeBaseOps[Z <: XmlZoomNodeBase](val zoom: Z) {
 
-    def /(nodeName: String): Z#Type = zoom.down(nodeName)
+    def /(nodeName: String): zoom.Type = zoom.down(nodeName)
 
-    def |(p: XmlPredicate): Z#Type = zoom.filter(p)
+    def |(p: XmlPredicate): zoom.Type = zoom.filter(p)
   }
 
   implicit class XmlContentZoomSyntaxForId(ns: NodeSeq) {

--- a/modules/core/src/test/scala-2/advxml/instances/ConvertersAssertsUtils.scala
+++ b/modules/core/src/test/scala-2/advxml/instances/ConvertersAssertsUtils.scala
@@ -1,0 +1,24 @@
+package advxml.instances
+
+import advxml.core.data.Converter
+import cats.Id
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.reflect.runtime.universe._
+
+private[instances] trait ConvertersAssertsUtils { $this: AnyFunSuite =>
+  protected implicit class TestConverterIdForSeqOps[I: TypeTag, O: TypeTag](converter: Converter[I, O])
+      extends TestConverterForSeqOps[Id, I, O](converter)
+
+  protected implicit class TestConverterForSeqOps[F[_], I: TypeTag, O: TypeTag](converter: Converter[I, F[O]]) {
+    def test(in: I, expectedOut: F[O])(implicit foTag: TypeTag[F[O]]): Unit = {
+      $this.test(
+        s"Converter[${typeOf[I].finalResultType}, ${foTag.tpe.finalResultType}]" +
+        s".apply('$in') should be '$expectedOut'"
+      ) {
+
+        assert(converter(in) == expectedOut)
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala-3/advxml/instances/ConvertersAssertsUtils.scala
+++ b/modules/core/src/test/scala-3/advxml/instances/ConvertersAssertsUtils.scala
@@ -1,0 +1,24 @@
+package advxml.instances
+
+import advxml.core.data.Converter
+import cats.Id
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.quoted.*
+
+private def showTypeImpl[T: Type](using Quotes): Expr[String] = {
+  import quotes.reflect.*
+  Expr(TypeRepr.of[T].show)
+}
+
+private inline def showType[T]: String = ${ showTypeImpl[T] }
+
+private[instances] trait ConvertersAssertsUtils { $this: AnyFunSuite =>
+  extension [I, O](converter: Converter[I, O]) {
+    inline def test(in: I, expectedOut: O): Unit = {
+      $this.test(s"Converter[${showType[I]}, ${showType[O]}].apply('$in') should be '$expectedOut'") {
+        assert(converter(in) == expectedOut)
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala/advxml/core/TypeInequalitiesTest.scala
+++ b/modules/core/src/test/scala/advxml/core/TypeInequalitiesTest.scala
@@ -7,12 +7,12 @@ class TypeInequalitiesTest extends AnyFlatSpec {
   import org.scalatest.matchers.should.Matchers._
 
   """
-    |def check[A, B](implicit ne: A =:!= B): Boolean = ne != null
-    |val res: Boolean = check[String, Int]
-    |""".stripMargin should compile
+    def check[A, B](implicit ne: A =:!= B): Boolean = ne != null
+    val res: Boolean = check[String, Int]
+    """ should compile
 
   """
-    |def check[A, B](implicit ne: A =:!= B): Boolean = ne != null
-    |val res: Boolean = check[String, String]
-    |""".stripMargin shouldNot compile
+    def check[A, B](implicit ne: A =:!= B): Boolean = ne != null
+    val res: Boolean = check[String, String]
+    """ shouldNot compile
 }

--- a/modules/core/src/test/scala/advxml/core/data/AggregatedExceptionTest.scala
+++ b/modules/core/src/test/scala/advxml/core/data/AggregatedExceptionTest.scala
@@ -3,7 +3,7 @@ package advxml.core.data
 import advxml.core.data.error.AggregatedException
 import cats.data.NonEmptyList
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers._
 
 /** Advxml
   * Created by geirolad on 29/07/2019.

--- a/modules/core/src/test/scala/advxml/core/transform/XmlTransformationSpec.scala
+++ b/modules/core/src/test/scala/advxml/core/transform/XmlTransformationSpec.scala
@@ -71,7 +71,7 @@ object XmlTransformationSpec extends Properties("XmlTransformationSpec") {
     }).run[Try](result.get).get === newElem
   }
 
-  property("Remove") = forAll(elemArbitrary.arbitrary.filter(_.child.nonEmpty)) { base: Elem =>
+  property("Remove") = forAll(elemArbitrary.arbitrary.filter(_.child.nonEmpty)) { (base: Elem) =>
     val zoom: XmlZoom = XmlGenerator
       .genZoom(base)
       .filter(_ != root)
@@ -93,7 +93,7 @@ object XmlTransformationSpec extends Properties("XmlTransformationSpec") {
     result.exists(attrs(k"numberOfAttributes" === base.attributes.size + attrsData.size))
   }
 
-  property("RemoveAttrs") = forAll { base: Elem =>
+  property("RemoveAttrs") = forAll { (base: Elem) =>
     val rule: ComposableXmlRule = root ==> RemoveAttrs(alwaysTrue)
     val result: NodeSeq = base.transform[Try](rule).get
 

--- a/modules/core/src/test/scala/advxml/instances/DataConvertInstancesTest.scala
+++ b/modules/core/src/test/scala/advxml/instances/DataConvertInstancesTest.scala
@@ -6,7 +6,6 @@ import advxml.core.transform.{XmlContentZoom, XmlContentZoomRunner}
 import advxml.implicits.$
 import advxml.instances.data.convert._
 import advxml.syntax.data._
-import cats.Id
 import cats.data.NonEmptyList
 import cats.data.Validated.Valid
 import org.scalatest.funsuite.AnyFunSuite
@@ -117,24 +116,4 @@ class ConvertersInstancesTestForText extends AnyFunSuite with ConvertersAssertsU
     Converter.of(ct => SimpleValue(ct.v.toString).nonEmpty)
     
   Converter[CustomType, Try[Text]].test(CustomType(1), Success(Text("1")))
-}
-
-private[instances] sealed trait ConvertersAssertsUtils { $this: AnyFunSuite =>
-
-  import scala.reflect.runtime.universe._
-
-  protected implicit class TestConverterIdForSeqOps[I: TypeTag, O: TypeTag](converter: Converter[I, O])
-    extends TestConverterForSeqOps[Id, I, O](converter)
-
-  protected implicit class TestConverterForSeqOps[F[_], I: TypeTag, O: TypeTag](converter: Converter[I, F[O]]) {
-    def test(in: I, expectedOut: F[O])(implicit foTag: TypeTag[F[O]]): Unit = {
-      $this.test(
-        s"Converter[${typeOf[I].finalResultType}, ${foTag.tpe.finalResultType}]" +
-          s".apply('$in') should be '$expectedOut'"
-      ) {
-        
-        assert(converter(in) == expectedOut)
-      }
-    }
-  }
 }

--- a/modules/core/src/test/scala/advxml/instances/TransformXmlModifierInstancesTest.scala
+++ b/modules/core/src/test/scala/advxml/instances/TransformXmlModifierInstancesTest.scala
@@ -2,7 +2,7 @@ package advxml.instances
 
 import advxml.core.transform.AbstractRule
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers._
 
 import scala.util.Try
 import scala.xml.NodeSeq

--- a/modules/core/src/test/scala/advxml/syntax/DataConvertFullSyntaxTest.scala
+++ b/modules/core/src/test/scala/advxml/syntax/DataConvertFullSyntaxTest.scala
@@ -33,11 +33,11 @@ class DataConvertFullSyntaxTest extends AnyFunSuite {
               (
                 car.attr("Brand").asValidated[String],
                 car.attr("Model").asValidated[String]
-              ).mapN(Car)
+              ).mapN(Car.apply)
             })
             .sequence
         }
-      ).mapN(Person)
+      ).mapN(Person.apply)
     })
 
     val xml =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,4 +19,18 @@ object Dependencies {
     "org.scalatest" %% "scalatest" % "3.2.9" % Test cross CrossVersion.binary,
     "org.scalacheck" %% "scalacheck" % "1.15.4" % Test cross CrossVersion.binary
   )
+
+  object Plugins {
+    lazy val compilerPluginsFor2: Seq[ModuleID] = Seq(
+      compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3" cross CrossVersion.binary)
+    )
+    lazy val compilerPluginsFor3: Seq[ModuleID] = Nil
+  }
+
+  lazy val extraDependenciesForScala2_12: Seq[ModuleID] =
+    Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0")
+
+  lazy val extraDependenciesForScala2_13: Seq[ModuleID] = Nil
+
+  lazy val extraDependenciesForScala3: Seq[ModuleID] = Nil
 }


### PR DESCRIPTION
Notable changes:
 - Added [scala-collection-compat](https://github.com/scala/scala-collection-compat) for [`@unused`](https://github.com/scala/scala-collection-compat/issues/369) support on Scala 2.12;
 - stole a slightly different implementation of `=:!=` from [shapeless](https://github.com/milessabin/shapeless/) since the current one doesn’t work on Scala 3 for some reason;
 - added a dedicated instance for `ValueExtractor[Id, SimpleValue]` because Scala 3 fails to find the instance from `Id`’s applicative instance (could be a compiler bug?);
 - implemented `ConvertersAssertsUtils` using Scala 3 [metaprogramming facilities](https://docs.scala-lang.org/scala3/guides/macros/reflection.html) since `TypeTag` is gone.