### PR TITLE
Fix SetAttrs example

### DIFF
--- a/modules/core/docs/Transform.md
+++ b/modules/core/docs/Transform.md
@@ -179,5 +179,5 @@ import cats.instances.try_._
 import advxml.implicits._
 
 val doc: Elem = <Root/>
-val result: Try[NodeSeq] = doc.transform[Try](root ==> SetAttrs("Attr1" := "TEST"))
+val result: Try[NodeSeq] = doc.transform[Try](root ==> SetAttrs(k"Attr1" := v"TEST"))
 ```


### PR DESCRIPTION
Add `k` and `v` interpolator to the example, otherwise it won't compile.